### PR TITLE
Updated clean_fac_col_txt to preserve dashes

### DIFF
--- a/R/clean_fac_col_txt.R
+++ b/R/clean_fac_col_txt.R
@@ -23,8 +23,8 @@
 clean_fac_col_txt <- function(x, to_upper = FALSE){
     # get rid of excessive white space
     out <- str_squish(x) %>%
-        # remove all special characters except spaces and dashes
-        str_remove_all("[^-|^[:space:]|^[:alnum:]]") %>%
+        # remove all special characters except spaces, dashes, and slashes
+        str_remove_all("[^-|^[:space:]|^[:alnum:]|^/]") %>%
         # capitalize COVID wherever its found
         str_replace_all("(?i)covid", "COVID") %>%
         # replace COVID - 19 with  some form of spaces with COVID-19

--- a/man/clean_fac_col_txt.Rd
+++ b/man/clean_fac_col_txt.Rd
@@ -16,7 +16,7 @@ cleaned character vector
 }
 \description{
 Cleans data usually associated with facilities or column names. Specifically
-removes special characters (except spaces and dashes), capitalizes COVID, standardizes
+removes special characters (except spaces, dashes, and slashes), capitalizes COVID, standardizes
 COVID-19 references, removes new line indicators and excess white space,
 and changes "state-wide" to "statewide" (case-insensitive).
 Optionally capitalizes output.


### PR DESCRIPTION
Tiny update to `clean_fac_col_txt` to preserve dashes in facility names. Not sure if this is actually what we would want or if it would cause downstream issues (e.g. when merging historical data), so feel free to close this PR if that's the case! 

* Previously: `clean_fac_col_txt("Jacksonville/PWC")` would return `"JacksonvillePWC"`
* Now: `clean_fac_col_txt("Jacksonville/PWC")` would return `"Jacksonville/PWC"`

This came up when noticing facility names on the website, where the Jacksonville/PWC example (from [here](https://www2.illinois.gov/idoc/facilities/Pages/Covid19Response.aspx)) shows up as `Jacksonvillepwc`. 