### PR TITLE
feature: group by coalesce speed up to help read_scrape_data

### DIFF
--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -45,6 +45,22 @@ read_scrape_data <- function(
         mutate(State = translate_state(State)) %>%
         clean_facility_name(debug = debug)
 
+    if(coalesce){
+        comb_df <- comb_df %>%
+            select(-id) %>%
+            group_by_coalesce(
+                Date, Name, State, jurisdiction, ID,
+                .ignore = c(
+                    "source", "scrape_name_clean", "federal_bool",
+                    "xwalk_name_clean", "name_match"),
+                .method = "sum", debug = debug)
+
+        if(debug){
+            message(stringr::str_c(
+                "Coalesced data frame contains ", nrow(comb_df), " rows."))
+        }
+    }
+
     full_df <- comb_df %>%
         filter(jurisdiction == "federal") %>%
         select(-State) %>%
@@ -70,19 +86,6 @@ read_scrape_data <- function(
         if(debug){
             message(stringr::str_c(
                 "State specific data frame contains ", nrow(out_df), " rows."))
-        }
-    }
-
-    if(coalesce){
-        out_df <- out_df %>%
-            select(-id) %>%
-            group_by_coalesce(
-                Date, Name, State, jurisdiction,
-                .ignore = "source", .method = "sum")
-
-        if(debug){
-            message(stringr::str_c(
-                "Coalesced data frame contains ", nrow(out_df), " rows."))
         }
     }
 

--- a/man/group_by_coalesce.Rd
+++ b/man/group_by_coalesce.Rd
@@ -4,7 +4,7 @@
 \alias{group_by_coalesce}
 \title{A all in one group by and coalesce function}
 \usage{
-group_by_coalesce(.data, ..., .ignore = c(), .method = "first")
+group_by_coalesce(.data, ..., .ignore = c(), .method = "first", debug = FALSE)
 }
 \arguments{
 \item{.data}{A data frame, data frame extension (e.g. a tibble), or a lazy
@@ -17,6 +17,8 @@ so expressions like x:y can be used to select a range of variable}
 \item{.ignore}{which columns to ignore for warnings}
 
 \item{.method}{either 'first' or 'sum'}
+
+\item{debug}{logical, print debug statements}
 }
 \value{
 vector of coalesced values
@@ -29,10 +31,10 @@ a warning is returned with the offending group, column name, and values.
 \examples{
 df_safe <- data.frame(
     A=c(1,1,2,2,2),
-    B=c(NA,2,NA,4,4),
+    B=c(NA,2,NA,NA,4),
     C=c(3,NA,NA,5,NA),
     D=c(NA,2,3,NA,NA),
-    E=c(NA,NA,NA,4,4))
+    E=c(NA,NA,NA,4,NA))
 
 df_warn <- data.frame(
     A=c(1,1,2,2,2),


### PR DESCRIPTION
made `group_by_coalesce` a lil better by adding a faster non-debug option

```
> system.time(read_scrape_data(TRUE, debug = TRUE))
Base data frame contains 55425 rows.
Coalesced data frame contains 51547 rows.
Named data frame contains 51547 rows.
Pop data frame contains 51547 rows.
   user  system elapsed 
566.520   0.345 569.451 
There were 50 or more warnings (use warnings() to see the first 50)
> system.time(read_scrape_data(TRUE, debug = FALSE))
   user  system elapsed 
 10.112   0.040  11.272 
```