### PR TITLE
Replaced Is.Federal with Jurisdiction

### DIFF
--- a/R/clean_facility_name.R
+++ b/R/clean_facility_name.R
@@ -26,7 +26,7 @@
 clean_facility_name <- function(dat, alt_name_xwalk = FALSE, debug = FALSE){
     if(alt_name_xwalk) {
       name_xwalk <- alt_name_xwalk
-    }else {
+    } else {
       name_xwalk <- read_fac_spellings()
     }
     check_jurisdiction <- see_if(dat %has_name% "jurisdiction")
@@ -52,25 +52,25 @@ clean_facility_name <- function(dat, alt_name_xwalk = FALSE, debug = FALSE){
              ))
 
     nonfederal_xwalk <- name_xwalk %>%
-      filter(Is.Federal == 0) %>%
-      select(-Is.Federal)
+        filter(Jurisdiction %in% c("state", "county")) %>%
+        select(-Jurisdiction)
 
     nonfederal <- dat %>%
-      filter(!federal_bool) %>%
-      left_join(nonfederal_xwalk,
-                by = c(
-                  "scrape_name_clean" = "xwalk_name_raw",
-                  "State" = "State")) %>%
-      mutate(Name = xwalk_name_clean) %>%
-      mutate(name_match = !is.na(Name)) %>%
-      mutate(Name = ifelse(is.na(Name), scrape_name_clean, Name))
+        filter(!federal_bool) %>%
+        left_join(nonfederal_xwalk,
+                  by = c(
+                      "scrape_name_clean" = "xwalk_name_raw",
+                      "State" = "State")) %>%
+        mutate(Name = xwalk_name_clean) %>%
+        mutate(name_match = !is.na(Name)) %>%
+        mutate(Name = ifelse(is.na(Name), scrape_name_clean, Name))
 
     nrow_nonfederal <- nrow(nonfederal)
     if(nrow_nonfederal == 0) {nonfederal <- NULL}
 
     federal_xwalk <- name_xwalk %>%
-      filter(Is.Federal == 1) %>%
-      select(-Is.Federal)
+        filter(Jurisdiction %in% c("federal", "immigration")) %>%
+        select(-Jurisdiction)
 
     federal <- dat %>%
         filter(federal_bool) %>%

--- a/R/read_fac_spellings.R
+++ b/R/read_fac_spellings.R
@@ -22,7 +22,7 @@ read_fac_spellings <- function(){
             State,
             xwalk_name_clean,
             xwalk_name_raw,
-            Is.Federal) %>%
+            Jurisdiction) %>%
         mutate(xwalk_name_clean = clean_fac_col_txt(str_to_upper(xwalk_name_clean))) %>%
         mutate(xwalk_name_raw = clean_fac_col_txt(str_to_upper(xwalk_name_raw))) %>%
         unique()


### PR DESCRIPTION
No more column name changes pretty please, my brain hurts. 

We replaced `Is.Federal` with `Jurisdiction` in fac_spellings so everything broken again. I just replaced the flag with explicit jurisdiction values - would love another set of eyes making sure I didn't mess anything up! 