### PR TITLE
Made columns explicit

### DIFF
--- a/R/read_fac_info.R
+++ b/R/read_fac_info.R
@@ -17,6 +17,10 @@
 read_fac_info <- function(federal_only = FALSE){
     FAC_DATA_LOC %>%
         read_csv(col_types = "dcccccccdcddddcccccddccc") %>%
+        select(Facility.ID, State, Name, Jurisdiction, Description, Security,
+               Age, Gender, Is.Different.Operator, Different.Operator, Population.Feb20,
+               Capacity, HIFLD.ID, BJS.ID, Source.Population.Feb20, Source.Capacity, Address,
+               City, Zipcode, Latitude, Longitude, County, County.FIPS, Website) %>%
         `if`(
             federal_only,
             filter(., stringr::str_detect(.$Jurisdiction, "(?i)federal")),

--- a/R/read_fac_spellings.R
+++ b/R/read_fac_spellings.R
@@ -29,7 +29,7 @@ read_fac_spellings <- function(){
         select(Facility.ID, State, xwalk_name_raw, xwalk_name_clean, Jurisdiction)
 
     out <- bind_rows(alt_spellings, clean_spellings) %>%
-        select(Facility.ID, State, xwalk_name_raw, xwalk_name_clean, Jurisdiction, Source) %>%
+        select(Facility.ID, State, xwalk_name_raw, xwalk_name_clean, Jurisdiction) %>%
         unique()
 
     return (out)

--- a/R/read_fac_spellings.R
+++ b/R/read_fac_spellings.R
@@ -15,15 +15,23 @@
 #' read_fac_spellings()
 
 read_fac_spellings <- function(){
-    FAC_SPELLINGS_LOC %>%
-        read_csv(col_types = cols()) %>%
-        select(
-            Facility.ID,
-            State,
-            xwalk_name_clean,
-            xwalk_name_raw,
-            Jurisdiction) %>%
+
+    # Add all alternative spellings
+    alt_spellings <- FAC_SPELLINGS_LOC %>%
+        read_csv(col_types = "dccccc") %>%
         mutate(xwalk_name_clean = clean_fac_col_txt(str_to_upper(xwalk_name_clean))) %>%
-        mutate(xwalk_name_raw = clean_fac_col_txt(str_to_upper(xwalk_name_raw))) %>%
-        unique()
+        mutate(xwalk_name_raw = clean_fac_col_txt(str_to_upper(xwalk_name_raw)))
+
+    # Add all entries in fac_info where the clean name is the same as the alt name
+    clean_spellings <- read_fac_info() %>%
+        mutate(xwalk_name_raw = Name,
+               xwalk_name_clean = Name) %>%
+        select(Facility.ID, State, xwalk_name_raw, xwalk_name_clean, Jurisdiction)
+
+    out <- bind_rows(alt_spellings, clean_spellings) %>%
+        select(Facility.ID, State, xwalk_name_raw, xwalk_name_clean, Jurisdiction, Source) %>%
+        unique() %>%
+
+    return (out)
+
 }

--- a/R/read_fac_spellings.R
+++ b/R/read_fac_spellings.R
@@ -30,7 +30,7 @@ read_fac_spellings <- function(){
 
     out <- bind_rows(alt_spellings, clean_spellings) %>%
         select(Facility.ID, State, xwalk_name_raw, xwalk_name_clean, Jurisdiction, Source) %>%
-        unique() %>%
+        unique()
 
     return (out)
 


### PR DESCRIPTION
For the Github as a Database(™) csv version control for the facility crosswalks, we're appending rows without column names to the existing files to track differences with commits. 

With that, I think we should have explicit `select` statements when we read the files to make sure we know exactly what columns we're reading and in what order. I also updated spellings to add all clean spellings (where `xwalk_name_clean == xwalk_name_raw`). In theory this should be reflected in the raw csv, but I think it's harmless (and potentially useful?) to also do it here. 