### PR TITLE
Updated read_scrape column order

### DIFF
--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -90,7 +90,8 @@ read_scrape_data <- function(
     }
 
     out_df <- out_df %>%
-        arrange(State, Name, Date)
+        arrange(State, Name, Date) %>%
+        reorder_cols()
 
     return(out_df)
 }

--- a/R/reorder_cols.R
+++ b/R/reorder_cols.R
@@ -26,9 +26,9 @@ reorder_cols <- function(data, add_missing_cols=TRUE, rm_extra_cols=FALSE) {
                       "Residents.Confirmed", "Staff.Confirmed", "Residents.Deaths", "Staff.Deaths",
                       "Residents.Recovered","Staff.Recovered", "Residents.Tadmin", "Staff.Tested",
                       "Residents.Negative","Staff.Negative", "Residents.Pending", "Staff.Pending",
-                      "Residents.Quarantine", "Staff.Quarantine", "Residents.Active", "Residents.Population",
-                      "Address", "Zipcode", "City", "County", "Latitude", "Longitude", "County.FIPS",
-                      "HIFLD.ID")
+                      "Residents.Quarantine", "Staff.Quarantine", "Residents.Active", "Population.Feb20",
+                      "Residents.Population", "Residents.Tested", "Address", "Zipcode", "City", "County",
+                      "Latitude", "Longitude", "County.FIPS", "HIFLD.ID")
     these_cols <- names(data)
     missing_cols <- if(all(scraper_cols %in% these_cols)) { NULL } else(base::setdiff(scraper_cols, these_cols))
     additional_cols <- if(all(these_cols %in% scraper_cols)) { NULL } else(base::setdiff(these_cols, scraper_cols))


### PR DESCRIPTION
Followed Hope's suggestion re: this issue: https://github.com/uclalawcovid19behindbars/behindbarstools/issues/63. 

Variable order is now: 
* Variables in Google Sheet 
* Other variables we scrape but don't report (`Residents.Population`, `Residents.Tested`) 
* Everything else 