### PR TITLE
Fix fac_spellings merge ambiguity on jurisdiction

### DIFF
--- a/R/clean_facility_name.R
+++ b/R/clean_facility_name.R
@@ -4,6 +4,15 @@
 #' Cleans federal and non-federal facilities in separate processes, in order to use "State" to merge or not.
 #' If no match is found in the crosswalk, both Facility.ID and Jurisdiction will equal NA in the resulting output.
 #'
+#' This function assumes that if a faceility is federal, then vars "Facility" OR "State" OR "Jurisdiction" will
+#' contain the word federal (case-insensitive).
+#'
+#' For non-federal entities, the data returned gets "Jurisdiction" from fac_spellings
+#'
+#' For federal + immigration entities, the data returned gets "Jurisdiction" and "State" from fac_spellings
+#'
+#' When there is not enough info to get a match, both "Jurisdiction" and "Facility.ID" will be returned as NA
+#'
 #' @param dat Scraped/historical data with columns Name and State, at the very least
 #' @param alt_name_xwalk Optional parameter provides an alternative facility name crosswalk
 #' @param debug Boolean whether to include additional columns geneated during the merging process

--- a/R/merge_facility_info.R
+++ b/R/merge_facility_info.R
@@ -12,7 +12,7 @@
 #'
 #' @examples
 #' merge_facility_info(
-#'     tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", jurisdiction = "state", Facility.ID = 7))
+#'     tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", Jurisdiction = "state", Facility.ID = 7))
 #'
 #'
 #' @export
@@ -24,12 +24,20 @@ merge_facility_info <- function(dat){
     left_join(fac_info,
               by = "Facility.ID",
               suffix = c("", ".y")) %>%
-    mutate(State = ifelse(is.na(State), State.y, State),
-           Jurisdiction = ifelse(is.na(jurisdiction), Jurisdiction, jurisdiction)) %>%
+    # if Name, State, or Jurisdiction are NA in data, use the values from fac_info
+    # note: we NEVER expect Name, State, or Jurisdiction to be in fac_info and
+    #       not fac_spellings. but in case this ever happens, the code below will
+    #       populate those missing values
+    mutate(
+      Name = ifelse(is.na(Name), Name.y, Name),
+      State = ifelse(is.na(State), State.y, State),
+      Jurisdiction = ifelse(is.na(Jurisdiction), Jurisdiction.y, Jurisdiction)
+      ) %>%
+    # de-select Name, State, and Jurisdiction from fac_info sheet
     select(
+      -Name.y,
       -State.y,
-      -jurisdiction,
-      -Name.y
+      -Jurisdiction.y,
     ) %>%
     relocate(Facility.ID)
 

--- a/R/read_fac_crosswalk.R
+++ b/R/read_fac_crosswalk.R
@@ -1,6 +1,6 @@
 #' Read in UCLA Prison and Jail Facility Data Crosswalk
 #'
-#' Reads in facility crosswalk data
+#' Reads in facility crosswalk data. NB:
 #'
 #' @return data frame with facility crosswalk data
 #'
@@ -12,8 +12,17 @@ read_fac_crosswalk <- function(){
     fac_spellings <- read_fac_spellings()
     fac_info <- read_fac_info()
     crosswalk <- left_join(fac_spellings, fac_info,
-                            by = c("xwalk_name_clean" = "Name",
-                                   "State" = "State")) %>%
+                            by = c("Facility.ID"),
+                           suffix = c("", ".y")) %>%
+        mutate(
+            State = ifelse(is.na(State), State.y, State),
+            Jurisdiction = ifelse(is.na(Jurisdiction), Jurisdiction.y, Jurisdiction)
+        ) %>%
+        # de-select Name, State, and Jurisdiction from fac_info sheet
+        select(
+            -State.y,
+            -Jurisdiction.y,
+        ) %>%
         unique()
-    crosswalk
+    return(crosswalk)
 }

--- a/man/clean_facility_name.Rd
+++ b/man/clean_facility_name.Rd
@@ -14,14 +14,18 @@ clean_facility_name(dat, alt_name_xwalk = FALSE, debug = FALSE)
 \item{debug}{Boolean whether to include additional columns geneated during the merging process}
 }
 \value{
-data set with cleaned facility name column, "Name", and "Facility.ID"
+data set with cleaned columns, "Name", "Facility.ID", and "Jurisdiction" from fac_spellings
 }
 \description{
 A facility name cleaning function. Uses GitHub facility name cross-walk to find all possible name variations.
-Cleans federal and non-federal facilities in separate processes, in order to use "State" to merge or not
+Cleans federal and non-federal facilities in separate processes, in order to use "State" to merge or not.
+If no match is found in the crosswalk, both Facility.ID and Jurisdiction will equal NA in the resulting output.
 }
 \examples{
 clean_facility_name(
-    tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", jurisdiction = "state"))
+    tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", Jurisdiction = "state"))
+
+clean_facility_name(
+    tibble(Name = "LEE USP", State = "Federal", Facility = "prison"))
 
 }

--- a/man/clean_facility_name.Rd
+++ b/man/clean_facility_name.Rd
@@ -21,6 +21,16 @@ A facility name cleaning function. Uses GitHub facility name cross-walk to find 
 Cleans federal and non-federal facilities in separate processes, in order to use "State" to merge or not.
 If no match is found in the crosswalk, both Facility.ID and Jurisdiction will equal NA in the resulting output.
 }
+\details{
+This function assumes that if a faceility is federal, then vars "Facility" OR "State" OR "Jurisdiction" will
+contain the word federal (case-insensitive).
+
+For non-federal entities, the data returned gets "Jurisdiction" from fac_spellings
+
+For federal + immigration entities, the data returned gets "Jurisdiction" and "State" from fac_spellings
+
+When there is not enough info to get a match, both "Jurisdiction" and "Facility.ID" will be returned as NA
+}
 \examples{
 clean_facility_name(
     tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", Jurisdiction = "state"))

--- a/man/merge_facility_info.Rd
+++ b/man/merge_facility_info.Rd
@@ -20,7 +20,7 @@ Data source here: https://github.com/uclalawcovid19behindbars/facility_data/data
 }
 \examples{
 merge_facility_info(
-    tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", jurisdiction = "state", Facility.ID = 7))
+    tibble(Name = "BULLOCK CORRECTIONAL FACILITY", State = "Alabama", Jurisdiction = "state", Facility.ID = 7))
 
 
 }

--- a/man/read_fac_crosswalk.Rd
+++ b/man/read_fac_crosswalk.Rd
@@ -10,5 +10,5 @@ read_fac_crosswalk()
 data frame with facility crosswalk data
 }
 \description{
-Reads in facility crosswalk data
+Reads in facility crosswalk data. NB:
 }

--- a/man/read_pop_data.Rd
+++ b/man/read_pop_data.Rd
@@ -10,7 +10,7 @@ read_pop_data()
 data frame with population data
 }
 \description{
-Reads in population data
+Reads in population data. If Facility.ID = NA, we don't have the pop data in our crosswalk.
 }
 \examples{
 read_pop_data()


### PR DESCRIPTION
- This function now assumes that for all of our data, if a facility is federal, then `Facility` OR `State` OR `Jurisdiction` will contain the word "federal". 
- For non-federal entities, the returned data gets "Jurisdiction" from fac_spellings
- For federal and immigration entities, the returned data gets "Jurisdiction" AND "State" from fac_spellings
- When there is not enough information to get a match, both "Jurisdiction" and "Facility.ID" are returned as NA

Example: 

```
test3 <- tibble(Name = "LEE USP", State = "Virginia", Facility = "Prison", n = 4) %>% # Jurisidction "federal" in xwalk, but not informative enough to get a match
  add_row(Name = "LEE USP", State = "federal", Facility = "Prison", n = 2001) # Jurisidction "federal" in xwalk

(out <- clean_facility_name(test3))

  Name                           State        n Facility.ID Jurisdiction
  <chr>                          <chr>    <dbl>       <dbl> <chr>       
1 LEE USP                        Virginia     4          NA NA          
2 LEE UNITED STATES PENITENTIARY Virginia  2001        1554 federal    
```

- If the input data has Name, State, or Jurisdiction as NA, and these values exist in fac_info, they are replaced within `merge_facility_info`. We expect our crosswalks to contain the same amount of information, so a fac_info merge should not return more information than a fac_spellings merge. But in case our crosswalks get out of sync, this is a safety measure. 