### PR TITLE
fix: scrape cols types

### DIFF
--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -107,5 +107,12 @@ read_scrape_data <- function(
         arrange(State, Name, Date) %>%
         reorder_cols()
 
+    if(!all_dates){
+        out_df <- out_df %>%
+            group_by(Facility.ID, jurisdiction_scraper, State, Name) %>%
+            filter(Date == max(Date)) %>%
+            ungroup()
+    }
+
     return(out_df)
 }

--- a/R/reorder_cols.R
+++ b/R/reorder_cols.R
@@ -22,16 +22,21 @@
 #' @export
 
 reorder_cols <- function(data, add_missing_cols=TRUE, rm_extra_cols=FALSE) {
-    scraper_cols <- c("Facility.ID", "Jurisdiction", "State", "Name", "Date", "source",
-                      "Residents.Confirmed", "Staff.Confirmed", "Residents.Deaths", "Staff.Deaths",
-                      "Residents.Recovered","Staff.Recovered", "Residents.Tadmin", "Staff.Tested",
-                      "Residents.Negative","Staff.Negative", "Residents.Pending", "Staff.Pending",
-                      "Residents.Quarantine", "Staff.Quarantine", "Residents.Active", "Population.Feb20",
-                      "Residents.Population", "Residents.Tested", 
-                      "Residents.Initiated", "Residents.Completed", "Residents.Vadmin", 
-                      "Staff.Initiated", "Staff.Completed", "Staff.Vadmin", 
-                      "Address", "Zipcode", "City", "County",
-                      "Latitude", "Longitude", "County.FIPS", "HIFLD.ID")
+    scraper_cols <- c(
+        "Facility.ID", "Jurisdiction", "State", "Name", "Date", "source",
+        "Residents.Confirmed", "Staff.Confirmed", "Residents.Deaths",
+        "Staff.Deaths", "Residents.Recovered","Staff.Recovered",
+        "Residents.Tadmin", "Staff.Tested", "Residents.Negative",
+        "Staff.Negative", "Residents.Pending", "Staff.Pending",
+        "Residents.Quarantine", "Staff.Quarantine", "Residents.Active",
+        "Population.Feb20", "Residents.Population", "Residents.Tested",
+        "Residents.Initiated", "Residents.Completed", "Residents.Vadmin",
+        "Staff.Initiated", "Staff.Completed", "Staff.Vadmin",
+        "Address", "Zipcode", "City", "County", "Latitude", "Longitude",
+        "County.FIPS", "HIFLD.ID", "jurisdiction_scraper", "Description",
+        "Security", "Age", "Gender", "Is.Different.Operator",
+        "Different.Operator", "Capacity", "BJS.ID", "Source.Population.Feb20",
+        "Source.Capacity", "Website")
     these_cols <- names(data)
     missing_cols <- if(all(scraper_cols %in% these_cols)) { NULL } else(base::setdiff(scraper_cols, these_cols))
     additional_cols <- if(all(these_cols %in% scraper_cols)) { NULL } else(base::setdiff(these_cols, scraper_cols))


### PR DESCRIPTION
bug fix for read_scrape_data returning an empty source col and just a safer read_csv call similar to Hopes recent PR