### PR TITLE
update: read scrape data not all dates fills in latest data with last value

### DIFF
--- a/man/read_scrape_data.Rd
+++ b/man/read_scrape_data.Rd
@@ -6,6 +6,7 @@
 \usage{
 read_scrape_data(
   all_dates = FALSE,
+  window = 31,
   coalesce = TRUE,
   debug = FALSE,
   state = NULL
@@ -13,6 +14,9 @@ read_scrape_data(
 }
 \arguments{
 \item{all_dates}{logical, get all data from all dates recorded by webscraper}
+
+\item{window}{int, if all dates is false how far back to look for values from
+a given facility to populate values until value should be NA}
 
 \item{coalesce}{logical, collapse common facilities into single row}
 


### PR DESCRIPTION
fill in the last observed value that was not NA  when read scrape data is latest so that when we miss part of states scrape like CA or when PA takes their dashboard down for a month we are still reporting recent data  within a given window specified by the user. Defaults to 31 days.

A downside to this is that read scrape data now takes a bit longer when `all_dates` equals false :/. No speed change when `all_dates` is true

![2021-02-09-091051_643x119_scrot](https://user-images.githubusercontent.com/5198764/107377785-55729a00-6ab9-11eb-9e55-c3bc8ef2b657.png)
