### PR TITLE
update: save ICE Field Office col in fac info

### DIFF
--- a/R/read_fac_info.R
+++ b/R/read_fac_info.R
@@ -40,12 +40,12 @@ read_fac_info <- function(federal_only = FALSE){
             County = "c",
             County.FIPS = "c",
             Website = "c",
-            Jurisdiction = "c")
-            ) %>%
+            Jurisdiction = "c",
+            ICE.Field.Office = "c")) %>%
         select(Facility.ID, State, Name, Jurisdiction, Description, Security,
                Age, Gender, Is.Different.Operator, Different.Operator, Population.Feb20,
                Capacity, HIFLD.ID, BJS.ID, Source.Population.Feb20, Source.Capacity, Address,
-               City, Zipcode, Latitude, Longitude, County, County.FIPS, Website) %>%
+               City, Zipcode, Latitude, Longitude, County, County.FIPS, Website, ICE.Field.Office) %>%
         `if`(
             federal_only,
             filter(., stringr::str_detect(.$Jurisdiction, "(?i)federal")),

--- a/R/reorder_cols.R
+++ b/R/reorder_cols.R
@@ -36,7 +36,7 @@ reorder_cols <- function(data, add_missing_cols=TRUE, rm_extra_cols=FALSE) {
         "County.FIPS", "HIFLD.ID", "jurisdiction_scraper", "Description",
         "Security", "Age", "Gender", "Is.Different.Operator",
         "Different.Operator", "Capacity", "BJS.ID", "Source.Population.Feb20",
-        "Source.Capacity", "Website")
+        "Source.Capacity", "Website", "ICE.Field.Office")
     these_cols <- names(data)
     missing_cols <- if(all(scraper_cols %in% these_cols)) { NULL } else(base::setdiff(scraper_cols, these_cols))
     additional_cols <- if(all(these_cols %in% scraper_cols)) { NULL } else(base::setdiff(these_cols, scraper_cols))


### PR DESCRIPTION
This PR will enable usage of the new `ICE.Field.Office` column added in by [this PR](https://github.com/uclalawcovid19behindbars/facility_data/pull/35). Should only be merged to master after the other PR has been merged otherwise it all breaks.