### PR TITLE
Updating read_scrape to match dates

### DIFF
--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -6,6 +6,8 @@
 #' @param window int, if all dates is false how far back to look for values from
 #' a given facility to populate values until value should be NA
 #' @param coalesce logical, collapse common facilities into single row
+#' @param coalesce_pop logical, collapse population data based on the date window
+#' @param drop_na_covid logical, drop rows missing all COVID variables
 #' @param debug logical, print debug statements on number of rows maintained in
 #' @param state character vector, states to limit data to
 #' cleaning process
@@ -23,7 +25,8 @@
 #' @export
 
 read_scrape_data <- function(
-    all_dates = FALSE, window = 31, coalesce = TRUE, debug = FALSE, state = NULL){
+    all_dates = FALSE, window = 31, coalesce = TRUE, coalesce_pop = TRUE,
+    drop_na_covid = TRUE, debug = FALSE, state = NULL){
 
     remote_loc <- stringr::str_c(
         SRVR_SCRAPE_LOC, "summary_data/aggregated_data.csv")
@@ -92,6 +95,31 @@ read_scrape_data <- function(
     }
 
     out_df <- merge_facility_info(comb_df)
+
+    if(coalesce_pop){
+        out_df <- out_df %>%
+            arrange(Facility.ID, Date) %>%
+            group_by(Facility.ID) %>%
+            # replace NA Residents.Population with values within date window
+            mutate(pop_date_ = ifelse(is.na(Residents.Population), NA, Date),
+                   pop_date_ = last_not_na(pop_date_),
+                   pop_fill_ = last_not_na(Residents.Population),
+                   Residents.Population = ifelse(
+                       !is.na(Facility.ID) & Date - pop_date_ < window,
+                       pop_fill_, Residents.Population)) %>%
+            select(-ends_with("_"))
+    }
+
+    if(drop_na_covid){
+        rowAny <- function(x) rowSums(x) > 0
+
+        out_df <- out_df %>%
+            # drop rows missing COVID data (e.g. only with population data)
+            filter(rowAny(across(ends_with(c(
+                ".Confirmed", ".Deaths", ".Recovered", ".Tadmin", ".Tested", ".Active",
+                ".Negative", ".Pending", ".Quarantine", ".Initiated", ".Completed", ".Vadmin")),
+                ~ !is.na(.x))))
+    }
 
     if(debug){
         message(stringr::str_c(

--- a/man/read_scrape_data.Rd
+++ b/man/read_scrape_data.Rd
@@ -8,6 +8,8 @@ read_scrape_data(
   all_dates = FALSE,
   window = 31,
   coalesce = TRUE,
+  coalesce_pop = TRUE,
+  drop_na_covid = TRUE,
   debug = FALSE,
   state = NULL
 )
@@ -19,6 +21,10 @@ read_scrape_data(
 a given facility to populate values until value should be NA}
 
 \item{coalesce}{logical, collapse common facilities into single row}
+
+\item{coalesce_pop}{logical, collapse population data based on the date window}
+
+\item{drop_na_covid}{logical, drop rows missing all COVID variables}
 
 \item{debug}{logical, print debug statements on number of rows maintained in}
 

--- a/man/read_scrape_data.Rd
+++ b/man/read_scrape_data.Rd
@@ -7,9 +7,10 @@
 read_scrape_data(
   all_dates = FALSE,
   window = 31,
+  window_pop = 31,
   coalesce = TRUE,
   coalesce_pop = TRUE,
-  drop_na_covid = TRUE,
+  drop_noncovid_obs = TRUE,
   debug = FALSE,
   state = NULL
 )
@@ -17,25 +18,27 @@ read_scrape_data(
 \arguments{
 \item{all_dates}{logical, get all data from all dates recorded by webscraper}
 
-\item{window}{int, if all dates is false how far back to look for values from
-a given facility to populate values until value should be NA}
+\item{window}{int, how far to go back (in days) to look for values from a given
+facility to populate NAs for ALL scraped variables. Used when all_dates is FALSE}
+
+\item{window_pop}{int, how far to go back (in days) to look for values from a given
+facility to populate NAs in Residents.Population. Used when coalesce_pop is TRUE}
 
 \item{coalesce}{logical, collapse common facilities into single row}
 
 \item{coalesce_pop}{logical, collapse population data based on the date window}
 
-\item{drop_na_covid}{logical, drop rows missing all COVID variables}
+\item{drop_noncovid_obs}{logical, drop rows missing all COVID variables}
 
 \item{debug}{logical, print debug statements on number of rows maintained in}
 
-\item{state}{character vector, states to limit data to
-cleaning process}
+\item{state}{character vector, states to limit data to}
 }
 \value{
-character vector of state names
+dataframe with scraped data
 }
 \description{
-Reads either time series or latest data from the web scraper runs
+Reads either time series or latest data from the web scraper runs.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Updates to `read_scrape_data` to: 
* Fixes the date mismatch issues (i.e. where we have `Residents.Population` data on 1/1/21 but run the scrapers on 1/2/21 and want to forward fill population data within a time window for a facility). 
* Drops rows where all COVID variables are NA (e.g. where we only have population data) 

A few things to note: 
* Both of these are parameters (`coalesce_pop` and `drop_na_covid`) that default to TRUE. Is that what we want? Are the names descriptive enough? Thought about renaming `coalesce` to `coalesce_facilities` but decided that might break things. 
* I'm using the same window parameter for the `all_dates = FALSE` forward-filling as historical population forward-filling. This feels okay to me, I think? 
* I decided to handle the date window here (as opposed to create a new version of `last_not_na` because it (1) felt like a cleaner solution (otherwise we'd have to pass around the Date vector and the Facility.ID vector to the function, which got messy with groupings, and (2) was MUCH faster (adding another looping nest over df rows was expensive). And I think we'll only really ever want to do this with population data, so I don't know if we necessarily need a fully modular function? 