### PR TITLE
Ungrouping read_scrape_data() 

### DIFF
--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -108,7 +108,8 @@ read_scrape_data <- function(
                    Residents.Population = ifelse(
                        !is.na(Facility.ID) & Date - pop_date_ < window_pop,
                        pop_fill_, Residents.Population)) %>%
-            select(-ends_with("_"))
+            select(-ends_with("_")) %>%
+            ungroup()
     }
 
     if(drop_noncovid_obs){


### PR DESCRIPTION
Sorry, I forgot to `ungroup()` after grouping by `Facility.ID` and we don't want to be returning grouped objects! 