### PR TITLE
update: add vaccine handling to aggregation

### DIFF
--- a/man/calc_aggregate_counts.Rd
+++ b/man/calc_aggregate_counts.Rd
@@ -4,7 +4,12 @@
 \alias{calc_aggregate_counts}
 \title{Aggregate UCLA and MP data to get a more recent accurate count of COVID variables}
 \usage{
-calc_aggregate_counts(window = 31, ucla_only = FALSE, state = FALSE)
+calc_aggregate_counts(
+  window = 31,
+  ucla_only = FALSE,
+  state = FALSE,
+  collapse_vaccine = TRUE
+)
 }
 \arguments{
 \item{window}{integer, the day range of acceptable data to pull from}
@@ -12,6 +17,9 @@ calc_aggregate_counts(window = 31, ucla_only = FALSE, state = FALSE)
 \item{ucla_only}{logical, only consider data from UCLA}
 
 \item{state}{logical, return state level data}
+
+\item{collapse_vaccine}{logical, combine vaccine variables for more
+intuitive comparisons.}
 }
 \value{
 data frame with aggregated counts at state or national level
@@ -20,7 +28,8 @@ data frame with aggregated counts at state or national level
 Reads the UCLA and MP/AP dataset aggregates counts for states for most recent
 data within a given window and reports either state level data or national
 data. States include values for the 50 states, Federal for BOP prisons, and
-District of Columbia for prison in the capitol.
+District of Columbia for prison in the capitol. If both UCLA and MP report a
+value for a state the larger value for is taken.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Updated the aggregation function to handle vaccine numbers in a more comparable way. Now when data is missing for vaccines administered it is replaced by initiated. If initiated is also missing then it is replaced by completed. This way Completed and Initiated should never be more than Administered.  

In addition include a column in the aggregation that has the agencies that are not reporting data.

[demo](https://docs.google.com/spreadsheets/d/1MCiyyaz1PtQX_AZ5sMRUOIOttbi8nqIvXCcPt4j4RIo/edit?usp=sharing) of the output with selected columns.