### PR TITLE
update: ts agg counts and keep date

### DIFF
--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -1,3 +1,10 @@
+max_na_rm <- function(x){
+    if(all(is.na(x))){
+        return(NA)
+    }
+    max(x, na.rm = TRUE)
+}
+
 #' Aggregate UCLA and MP data to get a more recent accurate count of COVID variables
 #'
 #' Reads the UCLA and MP/AP dataset aggregates counts for states for most recent
@@ -10,7 +17,9 @@
 #' @param ucla_only logical, only consider data from UCLA
 #' @param state logical, return state level data
 #' @param collapse_vaccine logical, combine vaccine variables for more
-#' intuitive comparisons.
+#' intuitive comparisons
+#' @param all_dates logical, get time series data rather than just latest counts
+#' @param week_grouping logical, use weekly grouping for past data? else monthly
 #'
 #' @return data frame with aggregated counts at state or national level
 #'
@@ -21,25 +30,43 @@
 #' @export
 
 calc_aggregate_counts <- function(
-    window = 31, ucla_only = FALSE, state = FALSE, collapse_vaccine = TRUE){
+    window = 31, ucla_only = FALSE, state = FALSE, collapse_vaccine = TRUE,
+    all_dates = FALSE, week_grouping = TRUE){
+
+    round_ <- ifelse(week_grouping, "week", "month")
 
     to_report <- c(datasets::state.name, "Federal", "ICE")
 
-    mp_data <- read_mpap_data(window = window) %>%
-        select(-Date) %>%
-        tidyr::pivot_longer(-State, names_to = "Measure", values_to = "MP")
+    mp_data_wide <- read_mpap_data(window = window, all_dates = all_dates)
+
+    if(all_dates){
+        mp_data <- mp_data_wide %>%
+            filter(!is.na(Date)) %>%
+            mutate(Date = lubridate::floor_date(Date, round_)) %>%
+            tidyr::pivot_longer(
+                -(State:Date), names_to = "Measure", values_to = "MP") %>%
+            group_by(State, Date, Measure) %>%
+            summarize(MP = max_na_rm(MP), .groups = "drop")
+    }
+    else{
+        mp_data <- mp_data_wide %>%
+            tidyr::pivot_longer(
+            -(State:Date), names_to = "Measure", values_to = "MP")
+    }
 
     if(ucla_only){
         mp_data$MP <- NA_real_
     }
 
-    ucla_df <- read_scrape_data(window = window)
+    ucla_df <- read_scrape_data(window = window, all_dates = all_dates)
 
-    state_df <- ucla_df %>%
+    state_wide_df <- ucla_df %>%
         mutate(State = ifelse(Jurisdiction == "federal", "Federal", State)) %>%
         mutate(State = ifelse(Jurisdiction == "immigration", "ICE", State)) %>%
         filter(Jurisdiction %in% c("state", "federal", "immigration")) %>%
-        select(Name, State, starts_with("Residents"), starts_with("Staff")) %>%
+        select(
+            Name, Date, State,
+            starts_with("Residents"), starts_with("Staff")) %>%
         select(-Residents.Population) %>%
         `if`(
             collapse_vaccine,
@@ -60,17 +87,45 @@ calc_aggregate_counts <- function(
             collapse_vaccine,
             mutate(., Residents.Vadmin = ifelse(
                 is.na(.$Residents.Vadmin), .$Residents.Completed, .$Residents.Vadmin)),
-            .) %>%
-        tidyr::pivot_longer(
-            -(Name:State), names_to = "Measure", values_to = "UCLA") %>%
-        filter(!is.na(UCLA)) %>%
-        group_by(State, Measure) %>%
-        mutate(has_statewide = "STATEWIDE" %in% Name) %>%
-        # if state wide and other counts exist for a measure only use statewide
-        filter(!(has_statewide & Name != "STATEWIDE")) %>%
-        group_by(State, Measure) %>%
-        summarise(UCLA = sum_na_rm(UCLA), .groups = "drop") %>%
-        full_join(mp_data, by = c("State", "Measure")) %>%
+            .)
+
+    if(all_dates){
+        state_df <- state_wide_df %>%
+            mutate(Date = lubridate::floor_date(Date, round_)) %>%
+            tidyr::pivot_longer(
+                -(Name:State), names_to = "Measure", values_to = "UCLA") %>%
+            filter(!is.na(UCLA)) %>%
+            group_by(State, Date, Measure, Name) %>%
+            summarize(UCLA = max_na_rm(UCLA), .groups = "drop_last") %>%
+            mutate(has_statewide = "STATEWIDE" %in% Name) %>%
+            # if state wide and other counts exist for a measure only use statewide
+            filter(!(has_statewide & Name != "STATEWIDE")) %>%
+            group_by(State, Date, Measure) %>%
+            summarise(UCLA = sum_na_rm(UCLA), .groups = "drop")
+
+        comb_df <- state_df %>%
+            full_join(mp_data, by = c("State", "Measure", "Date"))
+    }
+    else{
+        state_df <- state_wide_df %>%
+            tidyr::pivot_longer(
+                -(Name:State), names_to = "Measure", values_to = "UCLA") %>%
+            filter(!is.na(UCLA)) %>%
+            group_by(State, Measure) %>%
+            mutate(has_statewide = "STATEWIDE" %in% Name) %>%
+            # if state wide and other counts exist for a measure only use statewide
+            filter(!(has_statewide & Name != "STATEWIDE")) %>%
+            group_by(State, Measure) %>%
+            summarise(
+                UCLA = sum_na_rm(UCLA), Date = max(Date), .groups = "drop")
+
+        comb_df <- state_df %>%
+            rename(Date.UCLA = Date) %>%
+            full_join(
+                rename(mp_data, Date.MP = Date), by = c("State", "Measure"))
+    }
+
+    harm_df <- comb_df %>%
         mutate(Val = case_when(
             is.na(UCLA) & is.na(MP) ~ NA_real_,
             is.na(UCLA) ~ MP,
@@ -80,17 +135,23 @@ calc_aggregate_counts <- function(
         ))
 
     if(state){
-        return(state_df)
+        return(harm_df)
     }
 
-    agg_df <- state_df %>%
+    agg_df <- harm_df %>%
         filter(!is.na(Val)) %>%
-        group_by(Measure) %>%
+        group_by(Measure)
+
+    if(all_dates){
+        agg_df <- group_by(agg_df, Date, Measure)
+    }
+
+    out_agg_df <- agg_df %>%
         summarize(
             Count = sum_na_rm(Val), Reporting = sum(!is.na(Val)),
             Missing = paste0(
                 to_report[!(to_report %in% State)], collapse = ", "),
             .groups = "drop")
 
-    return(agg_df)
+    return(out_agg_df)
 }

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -13,7 +13,8 @@ max_na_rm <- function(x){
 #' District of Columbia for prison in the capitol. If both UCLA and MP report a
 #' value for a state the larger value for is taken.
 #'
-#' @param window integer, the day range of acceptable data to pull from
+#' @param window integer, the day range of acceptable data to pull from, ignored
+#' if all dates is true
 #' @param ucla_only logical, only consider data from UCLA
 #' @param state logical, return state level data
 #' @param collapse_vaccine logical, combine vaccine variables for more

--- a/man/calc_aggregate_counts.Rd
+++ b/man/calc_aggregate_counts.Rd
@@ -8,7 +8,9 @@ calc_aggregate_counts(
   window = 31,
   ucla_only = FALSE,
   state = FALSE,
-  collapse_vaccine = TRUE
+  collapse_vaccine = TRUE,
+  all_dates = FALSE,
+  week_grouping = TRUE
 )
 }
 \arguments{
@@ -19,7 +21,11 @@ calc_aggregate_counts(
 \item{state}{logical, return state level data}
 
 \item{collapse_vaccine}{logical, combine vaccine variables for more
-intuitive comparisons.}
+intuitive comparisons}
+
+\item{all_dates}{logical, get time series data rather than just latest counts}
+
+\item{week_grouping}{logical, use weekly grouping for past data? else monthly}
 }
 \value{
 data frame with aggregated counts at state or national level


### PR DESCRIPTION
Allow for TS comparisons of aggregate variables and comparisons to MP/AP data. In addition, changes keep date variables so that we can start to write the date to the sate totals sheet. In order to get time series data you must use the `all_dates` parameter similar to other functions

```
calc_aggregate_counts(all_dates = TRUE)
```

