### PR TITLE
chore: rm warning when group-wise value is all same and non-NA

### DIFF
--- a/R/group_by_coalesce.R
+++ b/R/group_by_coalesce.R
@@ -77,7 +77,6 @@ group_by_coalesce <- function(.data, ..., .ignore = c(), .method = "first", debu
         return(out)
     }
 
-
     out <- dplyr::bind_rows(lapply(z_list, function(z){
 
         z_group <- z %>%
@@ -100,7 +99,10 @@ group_by_coalesce <- function(.data, ..., .ignore = c(), .method = "first", debu
             }
             else{
                 xbar <- as.vector(na.omit(x))
-                if(length(xbar) != 1 & !(cn %in% .ignore)){
+                if(length(unique(xbar)) == 1) {
+                    out <- x[[1]]
+                }
+                else if(length(xbar) != 1 & !(cn %in% .ignore)){
                     warning(paste0(
                         "Group ", z_group_string,
                         " has multiple values that do not match for column ",


### PR DESCRIPTION
Test data set below. This change removes warning when there are multiple non-NA and identical values in a group, and doesn't use the `comb_vector` method for these cases. I think this will speed up `read_scrape_data`, although I didn't do any benchmarking

```
df_safe <- tibble(
        A=c(1,1,2,2,2),
        B=c(2,3,NA,NA,4),
        C=c("cat",NA,"samestring","samestring","samestring"),
        D=c(NA,2,3,NA,NA),
        E=c(18,18,NA,4,NA))
```