### PR TITLE
update: vacc agg fix

### DIFF
--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -75,23 +75,23 @@ calc_aggregate_counts <- function(
         select(-Residents.Population) %>%
         `if`(
             collapse_vaccine,
-            mutate(., Staff.Vadmin = ifelse(
-                is.na(.$Staff.Vadmin), .$Staff.Initiated, .$Staff.Vadmin)),
+            mutate(., Staff.Initiated = ifelse(
+                is.na(.$Staff.Initiated), .$Staff.Completed, .$Staff.Initiated)),
             .) %>%
         `if`(
             collapse_vaccine,
-            mutate(., Residents.Vadmin = ifelse(
-                is.na(.$Residents.Vadmin), .$Residents.Initiated, .$Residents.Vadmin)),
+            mutate(., Residents.Initiated = ifelse(
+                is.na(.$Residents.Initiated), .$Residents.Completed, .$Residents.Initiated)),
+            .)
+        `if`(
+            collapse_vaccine,
+            mutate(., Staff.Initiated = ifelse(
+                is.na(.$Staff.Initiated), .$Staff.Vadmin, .$Staff.Initiated)),
             .) %>%
         `if`(
             collapse_vaccine,
-            mutate(., Staff.Vadmin = ifelse(
-                is.na(.$Staff.Vadmin), .$Staff.Completed, .$Staff.Vadmin)),
-            .) %>%
-        `if`(
-            collapse_vaccine,
-            mutate(., Residents.Vadmin = ifelse(
-                is.na(.$Residents.Vadmin), .$Residents.Completed, .$Residents.Vadmin)),
+            mutate(., Residents.Initiated = ifelse(
+                is.na(.$Residents.Initiated), .$Residents.Vadmin, .$Residents.Initiated)),
             .)
 
     if(all_dates){

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -82,7 +82,7 @@ calc_aggregate_counts <- function(
             collapse_vaccine,
             mutate(., Residents.Initiated = ifelse(
                 is.na(.$Residents.Initiated), .$Residents.Completed, .$Residents.Initiated)),
-            .)
+            .) %>%
         `if`(
             collapse_vaccine,
             mutate(., Staff.Initiated = ifelse(


### PR DESCRIPTION
Because of the wording on our website it probably makes more sense to prioritize the vaccines initiated rather than other variables for aggregates. In order to get this to show up on the website we will need to ping hyperobject to change the variable that they are reading from `Vadmin` to `Initiated`. Nothing should break before notifying hyperobject.