### PR TITLE
update: add base_color param to theme

### DIFF
--- a/R/theme_behindbars.R
+++ b/R/theme_behindbars.R
@@ -34,24 +34,24 @@
 #'     }
 
 theme_behindbars <- function(
-    base_size = 24, base_family = "Helvetica") {
+    base_size = 24, base_family = "Helvetica", base_color = "#555526") {
 
     ggplot2::theme_classic(
         base_family = base_family,
         base_size = base_size
     ) +
         ggplot2::theme(
-            text =                element_text(color = "#555526"),
-            strip.text =          element_text(color = '#555526'),
-            axis.text =           element_text(color = "#555526"),
+            text =                element_text(color = base_color),
+            strip.text =          element_text(color = base_color),
+            axis.text =           element_text(color = base_color),
             panel.grid.major.y =  element_line(color = "#92926C", linetype = "dotted"),
             plot.title.position = "plot",
             plot.tag.position =   "bottomright",
             axis.line.y =         element_blank(),
             axis.ticks.y =        element_blank(),
             axis.title.x =        element_blank(),
-            axis.line =           element_line(color = "#555526"),
-            axis.ticks =          element_line(color = "#555526"),
+            axis.line =           element_line(color = base_color),
+            axis.ticks =          element_line(color = base_color),
             plot.caption =        element_text(margin = margin(t = 1.2 * base_size)),
             plot.subtitle =       element_text(margin = margin(b = 1.2 * base_size)),
             axis.title.y =        element_text(margin = margin(r = 1.2 * base_size)),

--- a/R/theme_behindbars.R
+++ b/R/theme_behindbars.R
@@ -7,6 +7,7 @@
 #'
 #' @param base_size base font size, given in pts
 #' @param base_family base font family
+#' @param base_color base color for text and axis lines
 #'
 #' @examples
 #' \dontrun{

--- a/man/theme_behindbars.Rd
+++ b/man/theme_behindbars.Rd
@@ -9,7 +9,11 @@
 \alias{scale_fill_bbcontinous}
 \title{Theme and colors for behind bars plots}
 \usage{
-theme_behindbars(base_size = 24, base_family = "Helvetica")
+theme_behindbars(
+  base_size = 24,
+  base_family = "Helvetica",
+  base_color = "#555526"
+)
 
 theme_map_behindbars(base_size = 24, base_family = "Helvetica")
 
@@ -25,6 +29,8 @@ scale_fill_bbcontinous()
 \item{base_size}{base font size, given in pts}
 
 \item{base_family}{base font family}
+
+\item{base_color}{base color for text and axis lines}
 }
 \description{
 a set of themes and colors for behind bars plots


### PR DESCRIPTION
Minor gripe: the axis, text, etc. color (`#555526`) in `theme_behindbars` makes plots look low-resolution (especially in slide decks, reports, etc.). Proposing moving that to a parameter to make it easier to make those a true black. 

```
p + theme_behindbars()
```
<img width="753" alt="Screen Shot 2021-04-11 at 11 13 42 AM" src="https://user-images.githubusercontent.com/47676353/114312086-fd571480-9ab6-11eb-8416-1f3a30d6e115.png">

```
p + theme_behindbars(base_color = "black")
```
<img width="752" alt="Screen Shot 2021-04-11 at 11 13 21 AM" src="https://user-images.githubusercontent.com/47676353/114312068-ee706200-9ab6-11eb-8fd1-58c09d448659.png">
