### PR TITLE
New long read scrape

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Encoding: UTF-8
 Depends: 
     R (>= 4.0.0),
     dplyr, 
-    ggplot2 
+    ggplot2,
+    data.table
 Imports:
     httr,
     jsonlite,

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -61,44 +61,21 @@ calc_aggregate_counts <- function(
         mp_data$MP <- NA_real_
     }
 
-    ucla_df <- read_scrape_data(window = window, all_dates = all_dates)
+    ucla_df <- read_scrape_data(
+        window = window, all_dates = all_dates, wide_data = FALSE)
 
-    state_wide_df <- ucla_df %>%
+    fac_long_df <- ucla_df %>%
         mutate(State = ifelse(Jurisdiction == "federal", "Federal", State)) %>%
         mutate(State = ifelse(Jurisdiction == "immigration", "ICE", State)) %>%
         filter(
             Jurisdiction %in% c("state", "federal", "immigration") |
                 (State == "District of Columbia" & Jurisdiction == "county")) %>%
-        select(
-            Name, Date, State,
-            starts_with("Residents"), starts_with("Staff")) %>%
-        select(-Residents.Population) %>%
-        `if`(
-            collapse_vaccine,
-            mutate(., Staff.Initiated = ifelse(
-                is.na(.$Staff.Initiated), .$Staff.Completed, .$Staff.Initiated)),
-            .) %>%
-        `if`(
-            collapse_vaccine,
-            mutate(., Residents.Initiated = ifelse(
-                is.na(.$Residents.Initiated), .$Residents.Completed, .$Residents.Initiated)),
-            .) %>%
-        `if`(
-            collapse_vaccine,
-            mutate(., Staff.Initiated = ifelse(
-                is.na(.$Staff.Initiated), .$Staff.Vadmin, .$Staff.Initiated)),
-            .) %>%
-        `if`(
-            collapse_vaccine,
-            mutate(., Residents.Initiated = ifelse(
-                is.na(.$Residents.Initiated), .$Residents.Vadmin, .$Residents.Initiated)),
-            .)
+        select(Name, Date, State, Measure, value)
 
     if(all_dates){
-        state_df <- state_wide_df %>%
+        state_df <- fac_long_df %>%
             mutate(Date = lubridate::floor_date(Date, round_)) %>%
-            tidyr::pivot_longer(
-                -(Name:State), names_to = "Measure", values_to = "UCLA") %>%
+            rename(UCLA = value) %>%
             filter(!is.na(UCLA)) %>%
             group_by(State, Date, Measure, Name) %>%
             summarize(UCLA = max_na_rm(UCLA), .groups = "drop_last") %>%
@@ -111,29 +88,86 @@ calc_aggregate_counts <- function(
             group_by(State, Date, Measure) %>%
             summarise(UCLA = sum_na_rm(UCLA), .groups = "drop")
 
+        if(collapse_vaccine){
+            sub_vac_res <- state_df %>%
+                group_by(State, Date) %>%
+                mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
+                filter(No.Initiated) %>%
+                # add vadmin in the vector if you also want to sub for that val
+                filter(Measure %in% c("Residents.Completed")) %>%
+                arrange(State, Measure, Date) %>%
+                filter(1:n() == 1) %>%
+                mutate(Measure = "Residents.Initiated") %>%
+                ungroup()
+
+            sub_vac_staff <- state_df %>%
+                group_by(State) %>%
+                mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
+                filter(No.Initiated) %>%
+                # add vadmin in the vector if you also want to sub for that val
+                filter(Measure %in% c("Staff.Completed")) %>%
+                arrange(State, Measure, Date) %>%
+                filter(1:n() == 1) %>%
+                mutate(Measure = "Staff.Initiated") %>%
+                ungroup()
+
+            state_df <- bind_rows(state_df, sub_vac_res, sub_vac_staff) %>%
+                select(-No.Initiated)
+        }
+
         comb_df <- state_df %>%
-            full_join(mp_data, by = c("State", "Measure", "Date"))
+            full_join(mp_data, by = c("State", "Measure", "Date")) %>%
+            arrange(State, Date, Measure)
     }
     else{
-        state_df <- state_wide_df %>%
-            tidyr::pivot_longer(
-                -(Name:State), names_to = "Measure", values_to = "UCLA") %>%
+        state_df <- fac_long_df %>%
+            rename(UCLA = value) %>%
             filter(!is.na(UCLA)) %>%
             group_by(State, Measure) %>%
             mutate(has_statewide = "STATEWIDE" %in% Name) %>%
-            # if state wide and other counts exist for a measure only take max date
+            # if state wide and other counts exist for a measure only take more
+            # recently scraped data
             filter(!(has_statewide) | Date == max(Date)) %>%
             mutate(has_statewide = "STATEWIDE" %in% Name) %>%
-            # if state wide and other counts still exist for a measure only use statewide
+            # if state wide and other counts still exist for a measure only
+            # use statewide measures
             filter(!(has_statewide & Name != "STATEWIDE")) %>%
             group_by(State, Measure) %>%
             summarise(
                 UCLA = sum_na_rm(UCLA), Date = max(Date), .groups = "drop")
 
+        if(collapse_vaccine){
+            sub_vac_res <- state_df %>%
+                group_by(State) %>%
+                mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
+                filter(No.Initiated) %>%
+                # add vadmin in the vector if you also want to sub for that val
+                filter(Measure %in% c("Residents.Completed")) %>%
+                arrange(State, Measure) %>%
+                filter(1:n() == 1) %>%
+                mutate(Measure = "Residents.Initiated") %>%
+                ungroup()
+
+            sub_vac_staff <- state_df %>%
+                group_by(State) %>%
+                mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
+                filter(No.Initiated) %>%
+                # add vadmin in the vector if you also want to sub for that val
+                filter(Measure %in% c("Staff.Completed")) %>%
+                arrange(State, Measure) %>%
+                filter(1:n() == 1) %>%
+                mutate(Measure = "Staff.Initiated") %>%
+                ungroup()
+
+            state_df <- bind_rows(state_df, sub_vac_res, sub_vac_staff) %>%
+                select(-No.Initiated)
+        }
+
         comb_df <- state_df %>%
             rename(Date.UCLA = Date) %>%
             full_join(
-                rename(mp_data, Date.MP = Date), by = c("State", "Measure"))
+                rename(mp_data, Date.MP = Date), by = c("State", "Measure")) %>%
+            arrange(State, Measure)
     }
 
     harm_df <- comb_df %>%

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -81,7 +81,7 @@ calc_aggregate_counts <- function(
             summarize(UCLA = max_na_rm(UCLA), .groups = "drop_last") %>%
             mutate(has_statewide = "STATEWIDE" %in% Name) %>%
             # if state wide and other counts exist for a measure only take max date
-            filter(!(has_statewide & Date == max(Date))) %>%
+            filter(!(has_statewide) | Date == max(Date)) %>%
             mutate(has_statewide = "STATEWIDE" %in% Name) %>%
             # if state wide and other counts still exist for a measure only use statewide
             filter(!(has_statewide & Name != "STATEWIDE")) %>%

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -142,7 +142,7 @@ calc_aggregate_counts <- function(
                 mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
                 filter(No.Initiated) %>%
                 # add vadmin in the vector if you also want to sub for that val
-                filter(Measure %in% c("Residents.Completed")) %>%
+                filter(Measure %in% c("Residents.Completed", "Residents.Vadmin")) %>%
                 arrange(State, Measure) %>%
                 filter(1:n() == 1) %>%
                 mutate(Measure = "Residents.Initiated") %>%
@@ -153,7 +153,7 @@ calc_aggregate_counts <- function(
                 mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
                 filter(No.Initiated) %>%
                 # add vadmin in the vector if you also want to sub for that val
-                filter(Measure %in% c("Staff.Completed")) %>%
+                filter(Measure %in% c("Staff.Completed", "Staff.Vadmin")) %>%
                 arrange(State, Measure) %>%
                 filter(1:n() == 1) %>%
                 mutate(Measure = "Staff.Initiated") %>%

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -93,20 +93,20 @@ calc_aggregate_counts <- function(
                 group_by(State, Date) %>%
                 mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
                 filter(No.Initiated) %>%
-                # add vadmin in the vector if you also want to sub for that val
-                filter(Measure %in% c("Residents.Completed")) %>%
-                arrange(State, Measure, Date) %>%
+                # remove vadmin in the vector if you dont want to sub for that val
+                filter(Measure %in% c("Residents.Completed", "Residents.Vadmin")) %>%
+                arrange(State, Date, Measure) %>%
                 filter(1:n() == 1) %>%
                 mutate(Measure = "Residents.Initiated") %>%
                 ungroup()
 
             sub_vac_staff <- state_df %>%
-                group_by(State) %>%
+                group_by(State, Date) %>%
                 mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
                 filter(No.Initiated) %>%
-                # add vadmin in the vector if you also want to sub for that val
-                filter(Measure %in% c("Staff.Completed")) %>%
-                arrange(State, Measure, Date) %>%
+                # add vadmin in the vector if you dont to sub for that val
+                filter(Measure %in% c("Staff.Completed", "Staff.Vadmin")) %>%
+                arrange(State, Date, Measure) %>%
                 filter(1:n() == 1) %>%
                 mutate(Measure = "Staff.Initiated") %>%
                 ungroup()

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -103,7 +103,10 @@ calc_aggregate_counts <- function(
             group_by(State, Date, Measure, Name) %>%
             summarize(UCLA = max_na_rm(UCLA), .groups = "drop_last") %>%
             mutate(has_statewide = "STATEWIDE" %in% Name) %>%
-            # if state wide and other counts exist for a measure only use statewide
+            # if state wide and other counts exist for a measure only take max date
+            filter(!(has_statewide & Date == max(Date))) %>%
+            mutate(has_statewide = "STATEWIDE" %in% Name) %>%
+            # if state wide and other counts still exist for a measure only use statewide
             filter(!(has_statewide & Name != "STATEWIDE")) %>%
             group_by(State, Date, Measure) %>%
             summarise(UCLA = sum_na_rm(UCLA), .groups = "drop")
@@ -118,7 +121,10 @@ calc_aggregate_counts <- function(
             filter(!is.na(UCLA)) %>%
             group_by(State, Measure) %>%
             mutate(has_statewide = "STATEWIDE" %in% Name) %>%
-            # if state wide and other counts exist for a measure only use statewide
+            # if state wide and other counts exist for a measure only take max date
+            filter(!(has_statewide) | Date == max(Date)) %>%
+            mutate(has_statewide = "STATEWIDE" %in% Name) %>%
+            # if state wide and other counts still exist for a measure only use statewide
             filter(!(has_statewide & Name != "STATEWIDE")) %>%
             group_by(State, Measure) %>%
             summarise(

--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -25,7 +25,8 @@
 
 read_scrape_data <- function(
     all_dates = FALSE, window = 31, window_pop = 31, coalesce = TRUE,
-    coalesce_pop = TRUE, drop_noncovid_obs = TRUE, debug = FALSE, state = NULL){
+    coalesce_pop = TRUE, drop_noncovid_obs = TRUE, debug = FALSE, state = NULL,
+    wide_data = TRUE){
 
     remote_loc <- stringr::str_c(
         SRVR_SCRAPE_LOC, "summary_data/aggregated_data.csv")
@@ -40,29 +41,29 @@ read_scrape_data <- function(
     ctypes[names(ctypes) == "Date"] <- "D"
 
     dat_df <- remote_loc %>%
-        readr::read_csv(col_types = paste0(ctypes, collapse = ""))
+        readr::read_csv(col_types = paste0(ctypes, collapse = "")) %>%
+        mutate(State = translate_state(State)) %>%
+        # rename this variable for clarity
+        rename(jurisdiction_scraper = jurisdiction) %>%
+        select(-starts_with("Resident.Deaths")) %>%
+        mutate(Name = clean_fac_col_txt(Name, to_upper = TRUE)) %>%
+        mutate(
+            pop_scraper = ifelse(stringr::str_detect(id, "pop"), T, F),
+            historical_covid = ifelse(stringr::str_detect(id, "pre-nov"), T, F)) %>%
+        tidyr::pivot_longer(starts_with(c("Residents", "Staff")))
+
 
     if(debug){
         message(stringr::str_c(
             "Base data frame contains ", nrow(dat_df), " rows."))
     }
 
-    dat_df <- dat_df %>%
-        mutate(State = translate_state(State)) %>%
-        # hack to remove old CA vaccine data for now
-        filter(id != "california_vaccine") %>%
-        # rename this variable for clarity
-        rename(jurisdiction_scraper = jurisdiction)
-
     cln_name_df <- dat_df %>%
-        select(-starts_with("Resident.Deaths")) %>%
-        mutate(Name = clean_fac_col_txt(Name, to_upper = TRUE)) %>%
         clean_facility_name(debug = debug) %>%
         # if Jurisdiction is NA (no match in facility_spellings), make it scraper jurisdiction
-        mutate(Jurisdiction = ifelse((is.na(Jurisdiction) & !is.na(jurisdiction_scraper)),
-                                     jurisdiction_scraper,
-                                     Jurisdiction)
-        )
+        mutate(Jurisdiction = ifelse(
+            (is.na(Jurisdiction) & !is.na(jurisdiction_scraper)),
+            jurisdiction_scraper, Jurisdiction))
 
     if(!is.null(state)){
         filt_df <- cln_name_df %>%
@@ -74,23 +75,49 @@ read_scrape_data <- function(
         }
     }
     else {
-        filt_df <- cln_name_df
+        filt_df <- as.data.table(cln_name_df)[!is.na(value), ]
     }
 
     if(coalesce){
-        comb_df <- filt_df %>%
-            arrange(Date, State, Name, jurisdiction_scraper, Facility.ID) %>%
-            mutate(pop_scraper = ifelse(stringr::str_detect(id, "pop"), 1, 0),
-                   historical_covid = ifelse(stringr::str_detect(id, "pre-nov"), 1, 0)) %>%
-            arrange(desc(historical_covid)) %>% # for res.confirmed etc: prioritize historical covid over scraper 2.0
-            arrange(desc(pop_scraper)) %>% # for res.pop: prioritize historical pop over historical covid
-            select(-id, -pop_scraper, -historical_covid) %>%
-            group_by_coalesce(
-                Date, Name, State, jurisdiction_scraper, Facility.ID,
-                .ignore = c(
-                    "source", "scrape_name_clean", "federal_bool",
-                    "xwalk_name_clean", "name_match", "Jurisdiction"),
-                .method = "first", debug = debug)
+
+        pop_full_df <- filt_df[name == "Residents.Population",]
+        pop_full_df[,
+                    singlepop := length(unique(pop_scraper)) == 1,
+                    by = list(
+                        Date, Name, State, jurisdiction_scraper, Facility.ID, name)]
+        pop_sub <- pop_full_df[pop_scraper | singlepop,]
+        pop_sub[,singlepop := NULL]
+
+        cov_full_df <- filt_df[name != "Residents.Population",]
+        cov_full_df[,
+                    singlescrape := length(unique(historical_covid)) == 1,
+                    by = list(
+                        Date, Name, State, jurisdiction_scraper, Facility.ID, name)]
+        cov_sub <- cov_full_df[singlescrape | historical_covid,]
+
+        var_sub_df <- bind_rows(pop_sub,cov_sub) %>%
+            select(-pop_scraper, -historical_covid, -singlescrape)
+
+        metric_df <- var_sub_df %>%
+            select(Date, Name, State, jurisdiction_scraper, Facility.ID, name, value)
+
+        metric_coal_df <- metric_df[,.(value = coalesce_func(value)), by = list(
+            Date, Name, State, jurisdiction_scraper, Facility.ID, name
+        )]
+
+        non_metric_df <- var_sub_df %>%
+            select(-value)
+
+        non_metric_coal_df <- non_metric_df[,lapply(.SD, first), by = list(
+            Date, Name, State, jurisdiction_scraper, Facility.ID, name
+        )]
+
+        comb_df <- left_join(
+            metric_coal_df, non_metric_coal_df,
+            by = c(
+                "Date", "Name", "State", "jurisdiction_scraper", "Facility.ID", "name"))
+
+        run_time <- Sys.time() - start_time
 
         if(debug){
             message(stringr::str_c(
@@ -101,54 +128,55 @@ read_scrape_data <- function(
         comb_df <- filt_df
     }
 
-    out_df <- merge_facility_info(comb_df)
-
-    if(coalesce_pop){
-        out_df <- out_df %>%
-            arrange(Facility.ID, Date) %>%
-            group_by(Facility.ID) %>%
-            # replace NA Residents.Population with values within date window
-            mutate(pop_date_ = ifelse(is.na(Residents.Population), NA, Date),
-                   pop_date_ = last_not_na(pop_date_),
-                   pop_fill_ = last_not_na(Residents.Population),
-                   Residents.Population = ifelse(
-                       !is.na(Facility.ID) & Date - pop_date_ < window_pop,
-                       pop_fill_, Residents.Population)) %>%
-            select(-ends_with("_")) %>%
-            ungroup()
-    }
-
-    if(drop_noncovid_obs){
-        rowAny <- function(x) rowSums(x) > 0
-
-        out_df <- out_df %>%
-            # drop rows missing COVID data (e.g. only with population data)
-            filter(rowAny(across(ends_with(c(
-                ".Confirmed", ".Deaths", ".Recovered", ".Tadmin", ".Tested", ".Active",
-                ".Negative", ".Pending", ".Quarantine", ".Initiated", ".Completed", ".Vadmin")),
-                ~ !is.na(.x))))
-    }
-
-    if(debug){
-        message(stringr::str_c(
-            "Named data frame contains ", nrow(out_df), " rows."))
-    }
-
-    out_df <- out_df %>%
-        arrange(State, Name, Date) %>%
-        reorder_cols()
+    out_df <- merge_facility_info(comb_df) %>%
+        rename(Measure = name) %>%
+        select(-id)
 
     if(!all_dates){
         out_df <- out_df %>%
             # only keep values in the last window of days
             filter(Date >= (Sys.Date() - window)) %>%
+            group_by(Facility.ID, jurisdiction_scraper, State, Name, Measure) %>%
+            arrange(Facility.ID, jurisdiction_scraper, State, Name, Measure, Date) %>%
+            # keep only last observed value
+            filter(1:n() == n()) %>%
+            # make all the sources the same
             group_by(Facility.ID, jurisdiction_scraper, State, Name) %>%
-            arrange(Facility.ID, jurisdiction_scraper, State, Name, Date) %>%
-            # replace all missing values with last observed real value
-            mutate(across(starts_with("Residents"), last_not_na)) %>%
-            mutate(across(starts_with("Staff"), last_not_na)) %>%
-            filter(Date == max(Date)) %>%
+            mutate(source = first(source)) %>%
             ungroup()
+    }
+
+    if(wide_data){
+        if(!all_dates){
+            out_df <- out_df %>%
+                group_by(
+                    Facility.ID, jurisdiction_scraper, State, Name) %>%
+                mutate(Date = max(Date)) %>%
+                ungroup()
+        }
+
+        out_df <- out_df %>%
+            tidyr::pivot_wider(names_from = Measure, values_from = value)
+
+        if(drop_noncovid_obs){
+            rowAny <- function(x) rowSums(x) > 0
+
+            out_df <- out_df %>%
+                # drop rows missing COVID data (e.g. only with population data)
+                filter(rowAny(across(ends_with(c(
+                    ".Confirmed", ".Deaths", ".Recovered", ".Tadmin", ".Tested", ".Active",
+                    ".Negative", ".Pending", ".Quarantine", ".Initiated", ".Completed", ".Vadmin")),
+                    ~ !is.na(.x))))
+        }
+
+        out_df <- out_df %>%
+            arrange(Facility.ID, jurisdiction_scraper, State, Name, Date) %>%
+            reorder_cols()
+    }
+
+    if(debug){
+        message(stringr::str_c(
+            "Named data frame contains ", nrow(out_df), " rows."))
     }
 
     return(out_df)

--- a/R/reorder_cols.R
+++ b/R/reorder_cols.R
@@ -29,14 +29,15 @@ reorder_cols <- function(data, add_missing_cols=TRUE, rm_extra_cols=FALSE) {
         "Residents.Tadmin", "Staff.Tested", "Residents.Negative",
         "Staff.Negative", "Residents.Pending", "Staff.Pending",
         "Residents.Quarantine", "Staff.Quarantine", "Residents.Active",
-        "Population.Feb20", "Residents.Population", "Residents.Tested",
-        "Residents.Initiated", "Residents.Completed", "Residents.Vadmin",
-        "Staff.Population", "Staff.Initiated", "Staff.Completed", "Staff.Vadmin",
-        "Address", "Zipcode", "City", "County", "Latitude", "Longitude",
-        "County.FIPS", "HIFLD.ID", "jurisdiction_scraper", "Description",
-        "Security", "Age", "Gender", "Is.Different.Operator",
-        "Different.Operator", "Capacity", "BJS.ID", "Source.Population.Feb20",
-        "Source.Capacity", "Website", "ICE.Field.Office")
+        "Staff.Active", "Population.Feb20", "Residents.Population",
+        "Residents.Tested", "Residents.Initiated", "Residents.Completed",
+        "Residents.Vadmin", "Staff.Population", "Staff.Initiated",
+        "Staff.Completed", "Staff.Vadmin", "Address", "Zipcode", "City",
+        "County", "Latitude", "Longitude", "County.FIPS", "HIFLD.ID",
+        "jurisdiction_scraper", "Description", "Security", "Age", "Gender",
+        "Is.Different.Operator", "Different.Operator", "Capacity", "BJS.ID",
+        "Source.Population.Feb20", "Source.Capacity", "Website",
+        "ICE.Field.Office")
     these_cols <- names(data)
     missing_cols <- if(all(scraper_cols %in% these_cols)) { NULL } else(base::setdiff(scraper_cols, these_cols))
     additional_cols <- if(all(these_cols %in% scraper_cols)) { NULL } else(base::setdiff(these_cols, scraper_cols))

--- a/man/read_scrape_data.Rd
+++ b/man/read_scrape_data.Rd
@@ -8,11 +8,11 @@ read_scrape_data(
   all_dates = FALSE,
   window = 31,
   window_pop = 31,
-  coalesce = TRUE,
-  coalesce_pop = TRUE,
+  coalesce_func = sum_na_rm,
   drop_noncovid_obs = TRUE,
   debug = FALSE,
-  state = NULL
+  state = NULL,
+  wide_data = TRUE
 )
 }
 \arguments{
@@ -24,15 +24,15 @@ facility to populate NAs for ALL scraped variables. Used when all_dates is FALSE
 \item{window_pop}{int, how far to go back (in days) to look for values from a given
 facility to populate NAs in Residents.Population. Used when coalesce_pop is TRUE}
 
-\item{coalesce}{logical, collapse common facilities into single row}
-
-\item{coalesce_pop}{logical, collapse population data based on the date window}
+\item{coalesce_func}{function, how to combine redundant rows}
 
 \item{drop_noncovid_obs}{logical, drop rows missing all COVID variables}
 
 \item{debug}{logical, print debug statements on number of rows maintained in}
 
 \item{state}{character vector, states to limit data to}
+
+\item{wide_data}{logical, return wide data as opposed to long}
 }
 \value{
 dataframe with scraped data


### PR DESCRIPTION
PR for changes in read scrape data which addresses the following issues
- Code base moved over to data table which improves speed of function by 4x
- Allows for long data returns which allows us to better preserve date of pulled data which was getting overwritten  with wide data
- Fixes issues in calc_aggergate where old statewide vaccine numbers were being prioritized
- When only recent wide data is returned removes redundant counts where both statewide and non-statewide values were collected
- Coalescing always happens now and you provide the function as a user defaults to sum_na_rm
- Reconciles old vs new scraper when both are collecting data at the same time (prioritizes old scraper)
- Reconciles dedicated vs non-dedicated population data  (prioritizes dedicated)
 
Draw back is the added dependency of the `data.table` R package

Some checks I have run:
 - make sure new and old return same number of facilities for default params
 - make sure aggregated calcs are about the same (we should expect some diffs with sum vs first)
 - make sure known past issues are fixed (issues with CA vaccine data)
