### PR TITLE
fix: unclog tempfile space

### DIFF
--- a/R/ExtractTable.R
+++ b/R/ExtractTable.R
@@ -85,6 +85,12 @@ ExtractTable <- function(img,  api_key = NULL) {
     }
 
     server_response <- process_file(api_key, img)
+
+    # Delete tempfile if exists
+    if(file.exists(f_)){
+        file.remove(f_)
+    }
+
     parsed_resp <- parse_response(server_response)
     # Wait for a maximum of 5 minutes to finish the trigger job
     # Retries every 20 seconds


### PR DESCRIPTION
Little patch to remove the png tempfile created in `ExtractTable()`. Overwriting the same tempfile was messy because R adds a hash string in the file path to make sure the names are unique – and I couldn't find a good way around this. But this effectively does the same thing. 