### PR TITLE
Update for manually collected youth facilities 

### DIFF
--- a/R/clean_facility_name.R
+++ b/R/clean_facility_name.R
@@ -74,7 +74,7 @@ clean_facility_name <- function(dat, alt_name_xwalk = FALSE, debug = FALSE){
                # include Jurisdiction, jurisdiction_scraper in federal_bool = TRUE
                str_detect(jurisdiction_scraper, "(?i)immigration") ~ TRUE,
                str_detect(Jurisdiction, "(?i)immigration") ~ TRUE,
-               # include youth facilities
+               # include manually collected youth facilities
                str_detect(jurisdiction_scraper, "(?i)youth") ~ TRUE,
                # when Jurisdiction is NA, and neither State nor Facility
                # contains "federal", federal_bool = FALSE
@@ -100,7 +100,8 @@ clean_facility_name <- function(dat, alt_name_xwalk = FALSE, debug = FALSE){
 
     federal_xwalk <- name_xwalk %>%
         filter(Jurisdiction %in% c("federal", "immigration") |
-              str_detect(xwalk_name_raw, ("(?i)youth facility"))) ## include youth
+              ## include manually collected youth facilities
+              str_detect(xwalk_name_raw, ("YOUTH FACILITY")))
 
     federal <- dat %>%
         filter(federal_bool) %>%

--- a/R/clean_facility_name.R
+++ b/R/clean_facility_name.R
@@ -74,6 +74,8 @@ clean_facility_name <- function(dat, alt_name_xwalk = FALSE, debug = FALSE){
                # include Jurisdiction, jurisdiction_scraper in federal_bool = TRUE
                str_detect(jurisdiction_scraper, "(?i)immigration") ~ TRUE,
                str_detect(Jurisdiction, "(?i)immigration") ~ TRUE,
+               # include youth facilities
+               str_detect(jurisdiction_scraper, "(?i)youth") ~ TRUE,
                # when Jurisdiction is NA, and neither State nor Facility
                # contains "federal", federal_bool = FALSE
                TRUE ~ FALSE
@@ -97,7 +99,8 @@ clean_facility_name <- function(dat, alt_name_xwalk = FALSE, debug = FALSE){
     if(nrow_nonfederal == 0) {nonfederal <- NULL}
 
     federal_xwalk <- name_xwalk %>%
-        filter(Jurisdiction %in% c("federal", "immigration"))
+        filter(Jurisdiction %in% c("federal", "immigration") |
+              str_detect(xwalk_name_raw, ("(?i)youth facility"))) ## include youth
 
     federal <- dat %>%
         filter(federal_bool) %>%


### PR DESCRIPTION
Example using both manually-collected and scraper-collected youth data: 

`dat <- tibble(Name = c("OKEECHOBEE SEX OFFENDER FACILITY YOUTH FACILITY FLORIDA", "AARON COHN RYDC YOUTH"), State = c("", "Georgia”), jurisdiction_scraper = c("youth", "state"))`

The way this works is that manually-collected youth facilities are assigned the jurisdiction_scraper `youth`, whereas scraper-collected youth facilities are assigned `state` or `county` jurisdiction directly in the scraper as per usual. 

Depends on changes implemented here: https://github.com/uclalawcovid19behindbars/covid19_behind_bars_scrapers/pull/268/files
