### PR TITLE
update: switch to date_cutoff

### DIFF
--- a/R/GLOBALS.R
+++ b/R/GLOBALS.R
@@ -9,3 +9,5 @@ FAC_DATA_LOC <- "https://raw.githubusercontent.com/uclalawcovid19behindbars/faci
 FAC_SPELLINGS_LOC <-"https://raw.githubusercontent.com/uclalawcovid19behindbars/facility_data/master/data/fac_spellings.csv"
 
 POP_ANCHOR_LOC <- "https://raw.githubusercontent.com/uclalawcovid19behindbars/data/master/anchored-data/state_aggregate_denominators.csv"
+
+DATE_CUTOFF <- as.Date("2021-06-01")

--- a/R/alt_aggregate_counts.R
+++ b/R/alt_aggregate_counts.R
@@ -1,13 +1,13 @@
 #' Alternate Aggregate UCLA data for website groupings
 #'
 #' Reads the UCLA aggregates counts for states for most recent
-#' data within a given window and reports either state level data or national
+#' data after a given date cutoff and reports either state level data or national
 #' data. States include values for the 50 states broken down by carceral type,
 #' prison, ICE, Federal, Juvenile, Psychiatric, and county. For prisons, data
 #' from the Marshall project is also incorporated.
 #'
-#' @param window integer, the day range of acceptable data to pull from, ignored
-#' if all dates is true
+#' @param date_cutoff date, the earliest date of acceptable data to pull from, 
+#' ignored if all dates is true
 #' @param all_dates logical, get time series data rather than just latest counts
 #' @param week_grouping logical, use weekly grouping for past data? else monthly
 #'
@@ -20,14 +20,14 @@
 #' @export
 
 alt_aggregate_counts <- function(
-    window = 31, all_dates = FALSE, week_grouping = TRUE){
+    date_cutoff = DATE_CUTOFF, all_dates = FALSE, week_grouping = TRUE){
 
     # How to round data when doing all dates
     round_ <- ifelse(week_grouping, "week", "month")
 
     # read in ucla data and do the appropriate grouping
     fac_long_df <- read_scrape_data(
-        window = window, all_dates = all_dates, wide_data = TRUE) %>%
+        date_cutoff = date_cutoff, all_dates = all_dates, wide_data = TRUE) %>%
         mutate(Web.Group = case_when(
             Jurisdiction == "immigration" ~ "ICE",
             Jurisdiction == "federal" ~ "Federal",
@@ -46,7 +46,7 @@ alt_aggregate_counts <- function(
 
     # pull in the comparable MP data
     mp_df <- read_mpap_data(
-        all_dates = all_dates, window = window) %>%
+        all_dates = all_dates, date_cutoff = date_cutoff) %>%
         filter(State != "Federal")%>%
         tidyr::pivot_longer(
             -(State:Date), names_to = "Measure", values_to = "MP")

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -1,14 +1,14 @@
 #' Aggregate UCLA and MP data to get a more recent accurate count of COVID variables
 #'
 #' Reads the UCLA and MP/AP dataset aggregates counts for states for most recent
-#' data within a given window and reports either state level data or national
+#' data after a given date cutoff and reports either state level data or national
 #' data. States include values for the 50 state DOCs, Federal for BOP prisons,
 #' ICE detention centers, and incarcerated individuals under the administration
 #' of the District of Columbia DOC. If both UCLA and MP report a
 #' value for a state the larger value for is taken.
 #'
-#' @param window integer, the day range of acceptable data to pull from, ignored
-#' if all dates is true
+#' @param date_cutoff date, the earliest date of acceptable data to pull from, 
+#' ignored if all dates is true
 #' @param ucla_only logical, only consider data from UCLA
 #' @param state logical, return state level data
 #' @param collapse_vaccine logical, combine vaccine variables for more
@@ -26,15 +26,15 @@
 #' @export
 
 calc_aggregate_counts <- function(
-    window = 31, ucla_only = FALSE, state = FALSE, collapse_vaccine = TRUE,
-    all_dates = FALSE, week_grouping = TRUE){
+    date_cutoff = DATE_CUTOFF, ucla_only = FALSE, state = FALSE, 
+    collapse_vaccine = TRUE, all_dates = FALSE, week_grouping = TRUE){
 
     round_ <- ifelse(week_grouping, "week", "month")
 
     to_report <- c(
         datasets::state.name, "Federal", "ICE", "District of Columbia")
 
-    mp_data_wide <- read_mpap_data(window = window, all_dates = all_dates)
+    mp_data_wide <- read_mpap_data(date_cutoff = date_cutoff, all_dates = all_dates)
 
     if(all_dates){
         mp_data <- mp_data_wide %>%
@@ -56,7 +56,7 @@ calc_aggregate_counts <- function(
     }
 
     ucla_df <- read_scrape_data(
-        window = window, all_dates = all_dates, wide_data = FALSE)
+        date_cutoff = date_cutoff, all_dates = all_dates, wide_data = FALSE)
 
     fac_long_df <- ucla_df %>%
         mutate(State = ifelse(Jurisdiction == "federal", "Federal", State)) %>%

--- a/R/read_mpap_data.R
+++ b/R/read_mpap_data.R
@@ -4,8 +4,8 @@
 #' UCLA dataset
 #'
 #' @param all_dates return all historical data from MP/AP
-#' @param window integer, the day range of acceptable data to pull from if
-#' all_dates is false
+#' @param date_cutoff date, the earliest date of acceptable data to pull from 
+#' if all_dates is false
 #'
 #' @return data frame with MP/AP results
 #'
@@ -15,7 +15,7 @@
 #' }
 #' @export
 
-read_mpap_data <- function(all_dates = FALSE, window = 14){
+read_mpap_data <- function(all_dates = FALSE, date_cutoff = DATE_CUTOFF){
     mp_raw_df <- "https://raw.githubusercontent.com/themarshallproject/" %>%
         stringr::str_c(
             "COVID_prison_data/master/data/covid_prison_cases.csv") %>%
@@ -42,7 +42,7 @@ read_mpap_data <- function(all_dates = FALSE, window = 14){
 
     if(!all_dates){
         rename_df <- rename_df %>%
-            filter(Date >= (Sys.Date() - window)) %>%
+            filter(Date >= date_cutoff) %>% 
             arrange(State, Date) %>%
             group_by(State) %>%
             mutate(across(where(is.numeric), last_not_na)) %>%

--- a/R/read_scrape_data.R
+++ b/R/read_scrape_data.R
@@ -3,10 +3,10 @@
 #' Reads either time series or latest data from the web scraper runs.
 #'
 #' @param all_dates logical, get all data from all dates recorded by webscraper
-#' @param window int, how far to go back (in days) to look for values from a given
-#' facility to populate NAs for ALL scraped variables. Used when all_dates is FALSE
+#' @param date_cutoff date, the earliest date of acceptable data to pull from 
+#' if all_dates is FALSE
 #' @param window_pop int, how far to go back (in days) to look for values from a given
-#' facility to populate NAs in Residents.Population. Used when coalesce_pop is TRUE
+#' facility to populate NAs in Residents.Population 
 #' @param coalesce_func function, how to combine redundant rows
 #' @param drop_noncovid_obs logical, drop rows missing all COVID variables
 #' @param debug logical, print debug statements on number of rows maintained in
@@ -24,8 +24,9 @@
 #' @export
 
 read_scrape_data <- function(
-    all_dates = FALSE, window = 31, window_pop = 31, coalesce_func = sum_na_rm,
-    drop_noncovid_obs = TRUE, debug = FALSE, state = NULL, wide_data = TRUE){
+    all_dates = FALSE, date_cutoff = DATE_CUTOFF, window_pop = 90, 
+    coalesce_func = sum_na_rm, drop_noncovid_obs = TRUE, debug = FALSE, 
+    state = NULL, wide_data = TRUE){
 
     remote_loc <- stringr::str_c(
         SRVR_SCRAPE_LOC, "summary_data/aggregated_data.csv")
@@ -187,8 +188,8 @@ read_scrape_data <- function(
 
     if(!all_dates){
         out_df <- out_df %>%
-            # only keep values in the last window of days
-            filter(Date >= (Sys.Date() - window)) %>%
+            # only keep values newer than date cutoff 
+            filter(Date >= date_cutoff) %>% 
             group_by(Facility.ID, jurisdiction_scraper, State, Name, Measure) %>%
             arrange(Facility.ID, jurisdiction_scraper, State, Name, Measure, Date) %>%
             # keep only last observed value

--- a/man/alt_aggregate_counts.Rd
+++ b/man/alt_aggregate_counts.Rd
@@ -4,11 +4,15 @@
 \alias{alt_aggregate_counts}
 \title{Alternate Aggregate UCLA data for website groupings}
 \usage{
-alt_aggregate_counts(window = 31, all_dates = FALSE, week_grouping = TRUE)
+alt_aggregate_counts(
+  date_cutoff = DATE_CUTOFF,
+  all_dates = FALSE,
+  week_grouping = TRUE
+)
 }
 \arguments{
-\item{window}{integer, the day range of acceptable data to pull from, ignored
-if all dates is true}
+\item{date_cutoff}{date, the earliest date of acceptable data to pull from, 
+ignored if all dates is true}
 
 \item{all_dates}{logical, get time series data rather than just latest counts}
 
@@ -19,7 +23,7 @@ data frame with aggregated counts at the state level by web groups
 }
 \description{
 Reads the UCLA aggregates counts for states for most recent
-data within a given window and reports either state level data or national
+data after a given date cutoff and reports either state level data or national
 data. States include values for the 50 states broken down by carceral type,
 prison, ICE, Federal, Juvenile, Psychiatric, and county. For prisons, data
 from the Marshall project is also incorporated.

--- a/man/calc_aggregate_counts.Rd
+++ b/man/calc_aggregate_counts.Rd
@@ -5,7 +5,7 @@
 \title{Aggregate UCLA and MP data to get a more recent accurate count of COVID variables}
 \usage{
 calc_aggregate_counts(
-  window = 31,
+  date_cutoff = DATE_CUTOFF,
   ucla_only = FALSE,
   state = FALSE,
   collapse_vaccine = TRUE,
@@ -14,8 +14,8 @@ calc_aggregate_counts(
 )
 }
 \arguments{
-\item{window}{integer, the day range of acceptable data to pull from, ignored
-if all dates is true}
+\item{date_cutoff}{date, the earliest date of acceptable data to pull from, 
+ignored if all dates is true}
 
 \item{ucla_only}{logical, only consider data from UCLA}
 
@@ -33,7 +33,7 @@ data frame with aggregated counts at state or national level
 }
 \description{
 Reads the UCLA and MP/AP dataset aggregates counts for states for most recent
-data within a given window and reports either state level data or national
+data after a given date cutoff and reports either state level data or national
 data. States include values for the 50 state DOCs, Federal for BOP prisons,
 ICE detention centers, and incarcerated individuals under the administration
 of the District of Columbia DOC. If both UCLA and MP report a

--- a/man/read_mpap_data.Rd
+++ b/man/read_mpap_data.Rd
@@ -4,13 +4,13 @@
 \alias{read_mpap_data}
 \title{Read the latest Marshall Project State Data}
 \usage{
-read_mpap_data(all_dates = FALSE, window = 14)
+read_mpap_data(all_dates = FALSE, date_cutoff = DATE_CUTOFF)
 }
 \arguments{
 \item{all_dates}{return all historical data from MP/AP}
 
-\item{window}{integer, the day range of acceptable data to pull from if
-all_dates is false}
+\item{date_cutoff}{date, the earliest date of acceptable data to pull from 
+if all_dates is false}
 }
 \value{
 data frame with MP/AP results

--- a/man/read_mpap_pop_data.Rd
+++ b/man/read_mpap_pop_data.Rd
@@ -15,6 +15,6 @@ resident population data closest to Feb 20, 2020.
 }
 \examples{
 \dontrun{
-read_staff_popfeb20()
+read_mpap_pop_data()
 }
 }

--- a/man/read_scrape_data.Rd
+++ b/man/read_scrape_data.Rd
@@ -6,8 +6,8 @@
 \usage{
 read_scrape_data(
   all_dates = FALSE,
-  window = 31,
-  window_pop = 31,
+  date_cutoff = DATE_CUTOFF,
+  window_pop = 90,
   coalesce_func = sum_na_rm,
   drop_noncovid_obs = TRUE,
   debug = FALSE,
@@ -18,11 +18,11 @@ read_scrape_data(
 \arguments{
 \item{all_dates}{logical, get all data from all dates recorded by webscraper}
 
-\item{window}{int, how far to go back (in days) to look for values from a given
-facility to populate NAs for ALL scraped variables. Used when all_dates is FALSE}
+\item{date_cutoff}{date, the earliest date of acceptable data to pull from 
+if all_dates is FALSE}
 
 \item{window_pop}{int, how far to go back (in days) to look for values from a given
-facility to populate NAs in Residents.Population. Used when coalesce_pop is TRUE}
+facility to populate NAs in Residents.Population}
 
 \item{coalesce_func}{function, how to combine redundant rows}
 


### PR DESCRIPTION
Opening this up as a draft PR re: #112. Code changes are really minor – just need to make sure we're all on board with this approach! 

One thing that I could go either way on (also mentioned in the issue) is whether to let window be a parameter, but then have something like: 
```
if (!is.null(window)){
    warning("Window has been depreciated as a parameter. Including all data later than 2021-06-01 instead. Specify a date_cutoff to change this threshold.")
```

I think it's probably good code practice to do so, but Hope brought up that it could also be confusing. 