### PR TITLE
Filter out youth facilities 

### DIFF
--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -7,7 +7,7 @@
 #' of the District of Columbia DOC. If both UCLA and MP report a
 #' value for a state the larger value for is taken.
 #'
-#' @param date_cutoff date, the earliest date of acceptable data to pull from, 
+#' @param date_cutoff date, the earliest date of acceptable data to pull from,
 #' ignored if all dates is true
 #' @param ucla_only logical, only consider data from UCLA
 #' @param state logical, return state level data
@@ -26,8 +26,9 @@
 #' @export
 
 calc_aggregate_counts <- function(
-    date_cutoff = DATE_CUTOFF, ucla_only = FALSE, state = FALSE, 
-    collapse_vaccine = TRUE, all_dates = FALSE, week_grouping = TRUE){
+    date_cutoff = DATE_CUTOFF, ucla_only = FALSE, state = FALSE,
+    collapse_vaccine = TRUE, all_dates = FALSE, week_grouping = TRUE,
+    only_prison = TRUE){
 
     round_ <- ifelse(week_grouping, "week", "month")
 
@@ -61,8 +62,9 @@ calc_aggregate_counts <- function(
     fac_long_df <- ucla_df %>%
         mutate(State = ifelse(Jurisdiction == "federal", "Federal", State)) %>%
         mutate(State = ifelse(Jurisdiction == "immigration", "ICE", State)) %>%
+        ## filter out juvenile, psychiatric, and most county facilities
         filter(
-            Jurisdiction %in% c("state", "federal", "immigration") |
+            Web.Group %in% c("Prison", "Federal", "ICE") |
                 (State == "District of Columbia" & Jurisdiction == "county")) %>%
         select(Name, Date, State, Measure, value)
 

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -15,6 +15,8 @@
 #' intuitive comparisons
 #' @param all_dates logical, get time series data rather than just latest counts
 #' @param week_grouping logical, use weekly grouping for past data? else monthly
+#' @param only_prison logical, whether to only include Prison, Federal, and ICE 
+#' web groups (state prisons, federal prisons, and ICE detention)
 #'
 #' @return data frame with aggregated counts at state or national level
 #'

--- a/man/calc_aggregate_counts.Rd
+++ b/man/calc_aggregate_counts.Rd
@@ -28,6 +28,9 @@ intuitive comparisons}
 \item{all_dates}{logical, get time series data rather than just latest counts}
 
 \item{week_grouping}{logical, use weekly grouping for past data? else monthly}
+
+\item{only_prison}{logical, whether to only include Prison, Federal, and ICE 
+web groups (state prisons, federal prisons, and ICE detention)}
 }
 \value{
 data frame with aggregated counts at state or national level

--- a/man/calc_aggregate_counts.Rd
+++ b/man/calc_aggregate_counts.Rd
@@ -10,11 +10,12 @@ calc_aggregate_counts(
   state = FALSE,
   collapse_vaccine = TRUE,
   all_dates = FALSE,
-  week_grouping = TRUE
+  week_grouping = TRUE,
+  only_prison = TRUE
 )
 }
 \arguments{
-\item{date_cutoff}{date, the earliest date of acceptable data to pull from, 
+\item{date_cutoff}{date, the earliest date of acceptable data to pull from,
 ignored if all dates is true}
 
 \item{ucla_only}{logical, only consider data from UCLA}


### PR DESCRIPTION
Addresses this and also sort of this
- https://github.com/uclalawcovid19behindbars/behindbarstools/issues/123
- https://github.com/uclalawcovid19behindbars/behindbarstools/issues/121

I realized I don't know what's causing the `alt_aggregate_counts` issue cited here: https://github.com/uclalawcovid19behindbars/behindbarstools/issues/123. Since we filter to Web.Group = "Prison" (`pri_df`) before merging with MP data and doing the case_when stuff, I'm not sure if this issue is relevant to `alt_aggregate_counts`. Would love someone to set me straight if I'm being slow here!