### PR TITLE
Proposed fix for reporting and missing column unexpected behavior

### DIFF
--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -205,12 +205,19 @@ calc_aggregate_counts <- function(
         agg_df <- group_by(agg_df, Date, Measure)
     }
 
-    out_agg_df <- agg_df %>%
+    UCLA_reporting_and_missing <- agg_df %>%
+        select(-Date.MP, -MP, -Val) %>%
+        filter(!is.na(UCLA)) %>%
         summarize(
-            Count = sum_na_rm(Val), Reporting = sum(!is.na(Val)),
+            Reporting = sum(!is.na(UCLA)),
             Missing = paste0(
-                to_report[!(to_report %in% State)], collapse = ", "),
-            .groups = "drop")
+                to_report[!(to_report %in% State)], collapse = ", "))
+
+    # Aggregate by Val, including MP, then add the reporting and missing
+    out_agg_df <- agg_df %>%
+        summarize(Count = sum_na_rm(Val)) %>%
+        merge(UCLA_reporting_and_missing)
+
 
     return(out_agg_df)
 }


### PR DESCRIPTION
[Issue 149](https://github.com/uclalawcovid19behindbars/behindbarstools/issues/149)
This code could be merged on its own to make the 'reported' and 'missing' columns refer to what was reported and missing for UCLA, rather than the current behavior. The current behavior counts a state as reporting if there is either data for UCLA or data from the Marshall Project from June. However...

If we move forward with removing references to the Marshall Project, the desired behavior (reported and missing both refer to UCLA's access to data) will happen on its own. OR if we move the global cutoff date to December 2021, then the behavior goes away on its own. BUT both options here will lower the cumulative counts substantially. I have to redo my comparison to be specific, but one thing I remember is that deaths go down by 233, for instance.

I think the least disruptive change to our data users would be to have the max ever cumulative figures available before either changing the cutoff date or removing the Marshall Project. But that's totally different work whose time requirement we don't know. So I think in the end, it may be best to merge this patch, but there's a good argument to be made for just dealing with the hit to cumulative figures too. Food for thought.