### PR TITLE
propose fix for collapse vaccine function addition

### DIFF
--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -88,7 +88,7 @@ calc_aggregate_counts <- function(
             group_by(State, Date, Measure) %>%
             summarise(UCLA = sum_na_rm(UCLA), .groups = "drop")
         
-        if(sub_vax) state_df <- .sub_vax_data(state_df, ad = all_dates)
+        if(sub_vax) state_df <- .sub_vax_data(state_df, all_dates)
 
         comb_df <- state_df %>%
             full_join(mp_data, by = c("State", "Measure", "Date")) %>%
@@ -115,7 +115,7 @@ calc_aggregate_counts <- function(
             summarise(
                 UCLA = sum_na_rm(UCLA), Date = max(Date), .groups = "drop")
 
-        if(sub_vax) state_df <- .sub_vax_data(state_df, ad = all_dates)
+        if(sub_vax) state_df <- .sub_vax_data(state_df, all_dates)
         
         comb_df <- state_df %>%
             rename(Date.UCLA = Date) %>%

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -29,7 +29,7 @@
 #' calc_aggregate_counts(state = TRUE, all_dates = TRUE)
 #' @export
 
-sub_vax_data <- function(df, ad = all_dates){
+sub_vax_data <- function(df, ad){
   grp_vars <- if(ad) c('State', 'Date') else c('State')
   arrange_vars <- if(ad) c('State', 'Date', 'Measure') else c('State', 'Measure')
   res <- df %>%
@@ -110,7 +110,7 @@ calc_aggregate_counts <- function(
             group_by(State, Date, Measure) %>%
             summarise(UCLA = sum_na_rm(UCLA), .groups = "drop")
         
-        if(collapse_vaccine) state_df <- sub_vax_data(state_df)
+        if(collapse_vaccine) state_df <- sub_vax_data(state_df, ad = all_dates)
 
         comb_df <- state_df %>%
             full_join(mp_data, by = c("State", "Measure", "Date")) %>%
@@ -137,7 +137,7 @@ calc_aggregate_counts <- function(
             summarise(
                 UCLA = sum_na_rm(UCLA), Date = max(Date), .groups = "drop")
 
-        if(collapse_vaccine) state_df <- sub_vax_data(state_df)
+        if(collapse_vaccine) state_df <- sub_vax_data(state_df, ad = all_dates)
         
         comb_df <- state_df %>%
             rename(Date.UCLA = Date) %>%

--- a/R/calc_aggregate_counts.R
+++ b/R/calc_aggregate_counts.R
@@ -13,8 +13,8 @@
 #' if all_dates is FALSE for all variables EXCEPT .Confirmed and .Deaths
 #' @param ucla_only logical, only consider data from UCLA
 #' @param state logical, return state level data
-#' @param collapse_vaccine logical, combine vaccine variables for more
-#' intuitive comparisons
+#' @param collapse_vaccine logical, add variable for Residents.Initiated, equal to Residents.Completed, 
+#' where Resident.Initiated is missing, by state, measure, and date when all_dates == T
 #' @param all_dates logical, get time series data rather than just latest counts
 #' @param week_grouping logical, use weekly grouping for past data? else monthly
 #' @param only_prison logical, whether to only include Prison, Federal, and ICE
@@ -28,6 +28,28 @@
 #' }
 #' calc_aggregate_counts(state = TRUE, all_dates = TRUE)
 #' @export
+
+sub_vax_data <- function(df, ad = all_dates){
+  grp_vars <- if(ad) c('State', 'Date') else c('State')
+  arrange_vars <- if(ad) c('State', 'Date', 'Measure') else c('State', 'Measure')
+  res <- df %>%
+    group_by_at(grp_vars) %>%
+    mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
+    filter(No.Initiated ) %>%
+    filter(Measure %in% c("Residents.Completed")) %>%
+    arrange_at(arrange_vars) %>%
+    filter(1:n() == 1) %>% #if there are duplicates, take the highest one
+    mutate(Measure = "Residents.Initiated")
+  staff <- df %>%
+    group_by_at(grp_vars) %>%
+    mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
+    filter(No.Initiated ) %>%
+    filter(Measure %in% c("Staff.Completed")) %>%
+    arrange_at(arrange_vars) %>%
+    filter(1:n() == 1) %>% #if there are duplicates, take the highest one
+    mutate(Measure = "Staff.Initiated") 
+  return(bind_rows(df, res, staff) %>% select(-No.Initiated))
+}
 
 calc_aggregate_counts <- function(
     date_cutoff = DATE_CUTOFF, window = 31, ucla_only = FALSE, state = FALSE,
@@ -87,33 +109,8 @@ calc_aggregate_counts <- function(
             filter(!(has_statewide & Name != "STATEWIDE")) %>%
             group_by(State, Date, Measure) %>%
             summarise(UCLA = sum_na_rm(UCLA), .groups = "drop")
-
-        if(collapse_vaccine){
-            sub_vac_res <- state_df %>%
-                group_by(State, Date) %>%
-                mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
-                filter(No.Initiated) %>%
-                # remove vadmin in the vector if you dont want to sub for that val
-                filter(Measure %in% c("Residents.Completed")) %>%
-                arrange(State, Date, Measure) %>%
-                filter(1:n() == 1) %>%
-                mutate(Measure = "Residents.Initiated") %>%
-                ungroup()
-
-            sub_vac_staff <- state_df %>%
-                group_by(State, Date) %>%
-                mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
-                filter(No.Initiated) %>%
-                # add vadmin in the vector if you dont to sub for that val
-                filter(Measure %in% c("Staff.Completed")) %>%
-                arrange(State, Date, Measure) %>%
-                filter(1:n() == 1) %>%
-                mutate(Measure = "Staff.Initiated") %>%
-                ungroup()
-
-            state_df <- bind_rows(state_df, sub_vac_res, sub_vac_staff) %>%
-                select(-No.Initiated)
-        }
+        
+        if(collapse_vaccine) state_df <- sub_vax_data(state_df)
 
         comb_df <- state_df %>%
             full_join(mp_data, by = c("State", "Measure", "Date")) %>%
@@ -140,33 +137,8 @@ calc_aggregate_counts <- function(
             summarise(
                 UCLA = sum_na_rm(UCLA), Date = max(Date), .groups = "drop")
 
-        if(collapse_vaccine){
-            sub_vac_res <- state_df %>%
-                group_by(State) %>%
-                mutate(No.Initiated = !("Residents.Initiated" %in% Measure)) %>%
-                filter(No.Initiated) %>%
-                # add vadmin in the vector if you also want to sub for that val
-                filter(Measure %in% c("Residents.Completed")) %>%
-                arrange(State, Measure) %>%
-                filter(1:n() == 1) %>%
-                mutate(Measure = "Residents.Initiated") %>%
-                ungroup()
-
-            sub_vac_staff <- state_df %>%
-                group_by(State) %>%
-                mutate(No.Initiated = !("Staff.Initiated" %in% Measure)) %>%
-                filter(No.Initiated) %>%
-                # add vadmin in the vector if you also want to sub for that val
-                filter(Measure %in% c("Staff.Completed")) %>%
-                arrange(State, Measure) %>%
-                filter(1:n() == 1) %>%
-                mutate(Measure = "Staff.Initiated") %>%
-                ungroup()
-
-            state_df <- bind_rows(state_df, sub_vac_res, sub_vac_staff) %>%
-                select(-No.Initiated)
-        }
-
+        if(collapse_vaccine) state_df <- sub_vax_data(state_df)
+        
         comb_df <- state_df %>%
             rename(Date.UCLA = Date) %>%
             full_join(


### PR DESCRIPTION
This takes the `collapse_vaccine` boolean argument and creates a function flexible to use with `all_dates == T` or `all_dates == F`. Should be compared and combined with issue 147 that does a similar change to create `state_df` flexibly considering the `all_dates` arg.